### PR TITLE
Set corrector_color of admin users to pass validations

### DIFF
--- a/lib/tasks/sample_data.rake
+++ b/lib/tasks/sample_data.rake
@@ -194,7 +194,8 @@ def create_users
                      admin:                 true,
                      year:                  1990,
                      country:               country[0],
-                     created_at:            DateTime.now - 100.days)
+                     created_at:            DateTime.now - 100.days,
+                     corrector_color:       User.generate_corrector_color)
   
   # Admin
   admin = User.create(first_name:            "Admin",
@@ -207,7 +208,8 @@ def create_users
                       admin:                 true,
                       year:                  1993,
                       country:               country[1],
-                      created_at:            DateTime.now - 90.days)
+                      created_at:            DateTime.now - 90.days,
+                      corrector_color:       User.generate_corrector_color)
                       
   # Students
   for i in 1..20


### PR DESCRIPTION
This PR fixes the following error:

```
$ rake db:populate
rake aborted!
NoMethodError: undefined method `upcase!' for nil:NilClass
/home/thibault/Documents/Programming/Web/mathraining/app/models/user.rb:69:in `validate'
/home/thibault/Documents/Programming/Web/mathraining/lib/tasks/sample_data.rake:187:in `create_users'
/home/thibault/Documents/Programming/Web/mathraining/lib/tasks/sample_data.rake:10:in `block (2 levels) in <top (required)>'
Tasks: TOP => db:populate
(See full trace by running task with --trace)
```