### PR TITLE
Replace onkeyup with oninput

### DIFF
--- a/app/views/actualities/_form.html.erb
+++ b/app/views/actualities/_form.html.erb
@@ -11,6 +11,6 @@
   <%= f.label :content, :for => "MathInput", :class => "form-label" %>
   <%= render 'shared/preview' %>
   <%= render 'shared/font' %>
-  <%= f.text_area :content, :class => "form-control", :maxlength => "8000", :style => "height:200px;", :id => "MathInput", :onkeyup => "Preview.MyUpdate()" %>
+  <%= f.text_area :content, :class => "form-control", :maxlength => "8000", :style => "height:200px;", :id => "MathInput", :oninput => "Preview.MyUpdate()" %>
   <script>initAndUpdatePreviewWhenPossible()</script>
 </div>

--- a/app/views/chapters/_all.html.erb
+++ b/app/views/chapters/_all.html.erb
@@ -10,7 +10,7 @@
     <div>
       <% numLatexTest += 1 if t.content.include? "latextest" %>
       <% if numLatexTest <= 1 %>
-        <%= raw(htmlise(t.content).gsub(/\/latextest\//, '<div class="mb-2"><div class="card text-bg-ld-light-dark"><div class="card-body" id="MathPreview"></div><div class="card-body hidden-preview" id="MathBuffer"></div></div><textarea id="MathInput" class="form-control mt-2" style="height:120px;" onkeyup="PreviewSafe.Update()" placeholder="Rentrez ici le code $\LaTeX$ que vous souhaitez tester."></textarea></div><script>initAndUpdatePreviewSafeWhenPossible(true)</script>')) %>
+        <%= raw(htmlise(t.content).gsub(/\/latextest\//, '<div class="mb-2"><div class="card text-bg-ld-light-dark"><div class="card-body" id="MathPreview"></div><div class="card-body hidden-preview" id="MathBuffer"></div></div><textarea id="MathInput" class="form-control mt-2" style="height:120px;" oninput="PreviewSafe.Update()" placeholder="Rentrez ici le code $\LaTeX$ que vous souhaitez tester."></textarea></div><script>initAndUpdatePreviewSafeWhenPossible(true)</script>')) %>
       <% else %>
         <%= raw(htmlise(t.content).gsub(/\/latextest\//, '<center><i>Voir plus haut.</i></center>')) %>
       <% end %>

--- a/app/views/chapters/_form.html.erb
+++ b/app/views/chapters/_form.html.erb
@@ -11,7 +11,7 @@
   <%= f.label :description, :for => "MathInput", :class => "form-label" %>
   <%= render 'shared/preview' %>
   <%= render 'shared/font' %>
-  <%= f.text_area :description, :class => "form-control", :maxlength => "8000", :style => "height:200px;", :id => "MathInput", :onkeyup => "Preview.MyUpdate()" %>
+  <%= f.text_area :description, :class => "form-control", :maxlength => "8000", :style => "height:200px;", :id => "MathInput", :oninput => "Preview.MyUpdate()" %>
   <script>initAndUpdatePreviewWhenPossible()</script>
 </div>
 

--- a/app/views/contestcorrections/_form.html.erb
+++ b/app/views/contestcorrections/_form.html.erb
@@ -2,9 +2,9 @@
 <%= render 'shared/preview' %>
 <%= render 'shared/smiley' %>
 <% if @ancientexte.nil? %>
-  <%= f.text_area :content, :class => "form-control", :maxlength => "8000", :style => "height:200px;", :id => "MathInput", :onkeyup => "PreviewSafe.MyUpdate()", :disabled => (current_user.other || !can_edit_correction) %>
+  <%= f.text_area :content, :class => "form-control", :maxlength => "8000", :style => "height:200px;", :id => "MathInput", :oninput => "PreviewSafe.MyUpdate()", :disabled => (current_user.other || !can_edit_correction) %>
 <% else %>
-  <%= f.text_area :content, :class => "form-control", :maxlength => "8000", :style => "height:200px;", :value => @ancientexte, :id => "MathInput", :onkeyup => "PreviewSafe.MyUpdate()", :disabled => (current_user.other || !can_edit_correction) %>
+  <%= f.text_area :content, :class => "form-control", :maxlength => "8000", :style => "height:200px;", :value => @ancientexte, :id => "MathInput", :oninput => "PreviewSafe.MyUpdate()", :disabled => (current_user.other || !can_edit_correction) %>
 <% end %>
 <script>initAndUpdatePreviewSafeWhenPossible()</script>
 <script>initLeavingFormWhenPossible()</script>

--- a/app/views/contestproblems/_form.html.erb
+++ b/app/views/contestproblems/_form.html.erb
@@ -11,7 +11,7 @@
   <%= f.label :statement, :for => "MathInput", :class => "form-label" %>
   <%= render 'shared/preview' %>
   <%= render 'shared/font' %>
-  <%= f.text_area :statement, :class => "form-control", :maxlength => "8000", :style => "height:200px;", :id => "MathInput", :onkeyup => "Preview.MyUpdate()" %>
+  <%= f.text_area :statement, :class => "form-control", :maxlength => "8000", :style => "height:200px;", :id => "MathInput", :oninput => "Preview.MyUpdate()" %>
   <script>initAndUpdatePreviewWhenPossible()</script>
 </div>
   

--- a/app/views/contests/_form.html.erb
+++ b/app/views/contests/_form.html.erb
@@ -9,7 +9,7 @@
   <%= f.label :description, :for => "MathInput", :class => "form-label" %>
   <%= render 'shared/preview' %>
   <%= render 'shared/smiley' %>
-  <%= f.text_area :description, :class => "form-control", :maxlength => "8000", :style => "height:200px;", :id => "MathInput", :onkeyup => "PreviewSafe.MyUpdate()", :disabled => current_user.other %>
+  <%= f.text_area :description, :class => "form-control", :maxlength => "8000", :style => "height:200px;", :id => "MathInput", :oninput => "PreviewSafe.MyUpdate()", :disabled => current_user.other %>
   <script>initAndUpdatePreviewSafeWhenPossible()</script>
 </div>
 

--- a/app/views/corrections/_new.html.erb
+++ b/app/views/corrections/_new.html.erb
@@ -10,9 +10,9 @@
 
     <% @ancientexte = session[:ancientexte] %>
     <% if @ancientexte.nil? %>
-      <%= f.text_area :content, :class => "form-control", :maxlength => "8000", :style => "height:200px;", :id => "MathInput", :onkeyup => "PreviewSafe.MyUpdate()", :disabled => (disable_correction || current_user.other) %>
+      <%= f.text_area :content, :class => "form-control", :maxlength => "8000", :style => "height:200px;", :id => "MathInput", :oninput => "PreviewSafe.MyUpdate()", :disabled => (disable_correction || current_user.other) %>
     <% else %>
-      <%= f.text_area :content, :class => "form-control", :maxlength => "8000", :value => @ancientexte, :style => "height:200px;", :id => "MathInput", :onkeyup => "PreviewSafe.MyUpdate()", :disabled => (disable_correction || current_user.other) %>
+      <%= f.text_area :content, :class => "form-control", :maxlength => "8000", :value => @ancientexte, :style => "height:200px;", :id => "MathInput", :oninput => "PreviewSafe.MyUpdate()", :disabled => (disable_correction || current_user.other) %>
     <% end %>
     <script>initAndUpdatePreviewSafeWhenPossible()</script>
     <script>initLeavingFormWhenPossible()</script>

--- a/app/views/discussions/new.html.erb
+++ b/app/views/discussions/new.html.erb
@@ -55,7 +55,7 @@ var UserNotFound = function () {
         <%= f.label :message, :for => "MathInput", :class => "form-label" %>
         <%= render 'shared/preview' %>
         <%= render 'shared/smiley' %>
-        <textarea name="content" maxlength="8000" class="form-control" style="height:120px;" id="MathInput" onkeyup="PreviewSafe.MyUpdate()" <%= 'disabled="disabled"' if current_user.other %> ><%= @ancientexte if !@ancientexte.nil? %></textarea>
+        <textarea name="content" maxlength="8000" class="form-control" style="height:120px;" id="MathInput" oninput="PreviewSafe.MyUpdate()" <%= 'disabled="disabled"' if current_user.other %> ><%= @ancientexte if !@ancientexte.nil? %></textarea>
         <script>initAndUpdatePreviewSafeWhenPossible()</script>
       </div>
       

--- a/app/views/discussions/show.html.erb
+++ b/app/views/discussions/show.html.erb
@@ -77,7 +77,7 @@ window.addEventListener("load", () => {
           <div class="mb-2">
             <%= render 'shared/preview' %>
             <%= render 'shared/smiley' %>
-            <textarea name="content" maxlength="8000" class="form-control" style="height:120px;" id="MathInput" onkeyup="PreviewSafe.MyUpdate()" <%= 'disabled="disabled"' if current_user.other %> ><%= @ancientexte if !@ancientexte.nil? %></textarea>
+            <textarea name="content" maxlength="8000" class="form-control" style="height:120px;" id="MathInput" oninput="PreviewSafe.MyUpdate()" <%= 'disabled="disabled"' if current_user.other %> ><%= @ancientexte if !@ancientexte.nil? %></textarea>
             <script>initAndUpdatePreviewSafeWhenPossible()</script>
           </div>
 

--- a/app/views/faqs/_form.html.erb
+++ b/app/views/faqs/_form.html.erb
@@ -11,6 +11,6 @@
   <%= f.label :answer, :for => "MathInput", :class => "form-label" %>
   <%= render 'shared/preview' %>
   <%= render 'shared/font' %>
-  <%= f.text_area :answer, :class => "form-control", :maxlength => "8000", :style => "height:200px;", :id => "MathInput", :onkeyup => "Preview.MyUpdate()" %>
+  <%= f.text_area :answer, :class => "form-control", :maxlength => "8000", :style => "height:200px;", :id => "MathInput", :oninput => "Preview.MyUpdate()" %>
   <script>initAndUpdatePreviewWhenPossible()</script>
 </div>

--- a/app/views/messages/_form.html.erb
+++ b/app/views/messages/_form.html.erb
@@ -27,7 +27,7 @@
   <%= f.label :content, :for => "MathInput#{postfix}", :disabled => current_user.other, :class => "form-label" %>
   <%= render 'shared/preview', postfix: postfix %>
   <%= render 'shared/smiley', postfix: postfix, hiddentext: true %>
-  <%= f.text_area :content, :value => cont, :maxlength => "8000", :class => "form-control", :style => "height:200px;", :id => "MathInput#{postfix}", :onkeyup => "PreviewSafe.MyUpdate()", :disabled => current_user.other %>
+  <%= f.text_area :content, :value => cont, :maxlength => "8000", :class => "form-control", :style => "height:200px;", :id => "MathInput#{postfix}", :oninput => "PreviewSafe.MyUpdate()", :disabled => current_user.other %>
   <!-- Do not call initAndUpdatePreviewSafeWhenPossible: it will be done only after rolling to show the form -->
 </div>
 

--- a/app/views/privacypolicies/edit.html.erb
+++ b/app/views/privacypolicies/edit.html.erb
@@ -10,7 +10,7 @@
     <%= f.label :content, :for => "MathInput", :class => "form-label" %>
     <%= render 'shared/preview' %>
     <%= render 'shared/font' %>
-    <%= f.text_area :content, :class => "form-control", :maxlength => "16000", :style => "height:200px;", :id => "MathInput", :onkeyup => "Preview.MyUpdate()" %>
+    <%= f.text_area :content, :class => "form-control", :maxlength => "16000", :style => "height:200px;", :id => "MathInput", :oninput => "Preview.MyUpdate()" %>
     <script>initAndUpdatePreviewWhenPossible()</script>
   </div>
   

--- a/app/views/privacypolicies/edit_description.html.erb
+++ b/app/views/privacypolicies/edit_description.html.erb
@@ -10,7 +10,7 @@
     <%= f.label :description, :for => "MathInput", :class => "form-label" %>
     <%= render 'shared/preview' %>
     <%= render 'shared/font' %>
-    <%= f.text_area :description, :class => "form-control", :maxlength => "8000", :style => "height:200px;", :id => "MathInput", :onkeyup => "Preview.MyUpdate()" %>
+    <%= f.text_area :description, :class => "form-control", :maxlength => "8000", :style => "height:200px;", :id => "MathInput", :oninput => "Preview.MyUpdate()" %>
     <script>initAndUpdatePreviewWhenPossible()</script>
   </div>
   

--- a/app/views/problems/_form.html.erb
+++ b/app/views/problems/_form.html.erb
@@ -5,7 +5,7 @@
   <%= f.label "Énoncé", :for => "MathInput", :class => "form-label" %>
   <%= render 'shared/preview' %>
   <%= render 'shared/font' %>
-  <%= f.text_area :statement, :class => "form-control", :maxlength => "8000", :style => "height:200px;", :id => "MathInput", :onkeyup => "Preview.MyUpdate()" %>
+  <%= f.text_area :statement, :class => "form-control", :maxlength => "8000", :style => "height:200px;", :id => "MathInput", :oninput => "Preview.MyUpdate()" %>
   <script>initAndUpdatePreviewWhenPossible()</script>
 </div>
   

--- a/app/views/problems/edit_explanation.html.erb
+++ b/app/views/problems/edit_explanation.html.erb
@@ -16,7 +16,7 @@ Son but est de donner les grandes idées de la solution afin de faciliter la tâ
   <div class="mb-2">
     <%= render 'shared/preview' %>
     <%= render 'shared/font' %>
-    <%= f.text_area :explanation, :class => "form-control", :style => "height:200px;", :id => "MathInput", :onkeyup => "Preview.MyUpdate()" %>
+    <%= f.text_area :explanation, :class => "form-control", :style => "height:200px;", :id => "MathInput", :oninput => "Preview.MyUpdate()" %>
     <script>initAndUpdatePreviewWhenPossible()</script>
   </div>
   <%= f.submit "Modifier", class: "btn btn-lg btn-primary" %>

--- a/app/views/problems/edit_markscheme.html.erb
+++ b/app/views/problems/edit_markscheme.html.erb
@@ -21,7 +21,7 @@
   <div class="mb-2">
     <%= render 'shared/preview' %>
     <%= render 'shared/font' %>
-    <%= f.text_area :markscheme, :class => "form-control", :style => "height:200px;", :id => "MathInput", :onkeyup => "Preview.MyUpdate()" %>
+    <%= f.text_area :markscheme, :class => "form-control", :style => "height:200px;", :id => "MathInput", :oninput => "Preview.MyUpdate()" %>
     <script>initAndUpdatePreviewWhenPossible()</script>
   </div>
   <%= f.submit "Modifier", class: "btn btn-lg btn-primary" %>

--- a/app/views/questions/_form.html.erb
+++ b/app/views/questions/_form.html.erb
@@ -5,7 +5,7 @@
   <%= f.label "Énoncé", :for => "MathInput", :class => "form-label" %>
   <%= render 'shared/preview' %>
   <%= render 'shared/font' %>
-  <%= f.text_area :statement, :class => "form-control", :maxlength => "8000", :style => "height:200px;", :id => "MathInput", :onkeyup => "Preview.MyUpdate()" %>
+  <%= f.text_area :statement, :class => "form-control", :maxlength => "8000", :style => "height:200px;", :id => "MathInput", :oninput => "Preview.MyUpdate()" %>
   <script>initAndUpdatePreviewWhenPossible()</script>
 </div>
 

--- a/app/views/questions/edit_explanation.html.erb
+++ b/app/views/questions/edit_explanation.html.erb
@@ -20,7 +20,7 @@
   <div class="mb-2">
     <%= render 'shared/preview' %>
     <%= render 'shared/font' %>
-    <%= f.text_area :explanation, :class => "form-control", :maxlength => "8000", :style => "height:200px;", :id => "MathInput", :onkeyup => "Preview.MyUpdate()" %>
+    <%= f.text_area :explanation, :class => "form-control", :maxlength => "8000", :style => "height:200px;", :id => "MathInput", :oninput => "Preview.MyUpdate()" %>
     <script>initAndUpdatePreviewWhenPossible()</script>
   </div>
   <%= f.submit "Modifier", class: "btn btn-lg btn-primary" %>

--- a/app/views/sections/edit.html.erb
+++ b/app/views/sections/edit.html.erb
@@ -29,7 +29,7 @@
     <%= f.label :description, :for => "MathInput", :class => "form-label" %>
     <%= render 'shared/preview' %>
     <%= render 'shared/font' %>
-    <%= f.text_area :description, :class => "form-control", :maxlength => "8000", :style => "height:200px;", :id => "MathInput", :onkeyup => "Preview.MyUpdate()" %>
+    <%= f.text_area :description, :class => "form-control", :maxlength => "8000", :style => "height:200px;", :id => "MathInput", :oninput => "Preview.MyUpdate()" %>
     <script>initAndUpdatePreviewWhenPossible()</script>
   </div>
   <%= f.submit "Modifier", class: "btn btn-lg btn-primary" %>

--- a/app/views/subjects/_form.html.erb
+++ b/app/views/subjects/_form.html.erb
@@ -293,7 +293,7 @@ function checkWepion() {
   <%= f.label :content, :for => "MathInput#{postfix}", :class => "form-label", :disabled => current_user.other %>
   <%= render 'shared/preview', postfix: postfix %>
   <%= render 'shared/smiley', postfix: postfix, hiddentext: true %>
-  <%= f.text_area :content, :class => "form-control", :maxlength => "8000", :style => "height:200px;", :id=>"MathInput#{postfix}", :onkeyup => "PreviewSafe.MyUpdate()", :disabled => current_user.other, :value => cont %>
+  <%= f.text_area :content, :class => "form-control", :maxlength => "8000", :style => "height:200px;", :id=>"MathInput#{postfix}", :oninput => "PreviewSafe.MyUpdate()", :disabled => current_user.other, :value => cont %>
   <% if is_edit %>
     <!-- Do not call initAndUpdatePreviewSafeWhenPossible(): it will be done only after rolling to show the form -->
   <% else %>

--- a/app/views/submissions/_form.html.erb
+++ b/app/views/submissions/_form.html.erb
@@ -8,9 +8,9 @@
   <%= render 'shared/preview' %>
   <%= render 'shared/smiley' %>
   <% if @ancientexte.nil? %>
-    <%= f.text_area :content, :class => "form-control", :maxlength => "8000", :style => "height:200px;", :id => "MathInput", :onkeyup => "PreviewSafe.MyUpdate()", :disabled => (current_user.other || form_disabled) %>
+    <%= f.text_area :content, :class => "form-control", :maxlength => "8000", :style => "height:200px;", :id => "MathInput", :oninput => "PreviewSafe.MyUpdate()", :disabled => (current_user.other || form_disabled) %>
   <% else %>
-    <%= f.text_area :content, :class => "form-control", :maxlength => "8000", :style => "height:200px;", :value => @ancientexte, :id => "MathInput", :onkeyup => "PreviewSafe.MyUpdate()", :disabled => (current_user.other || form_disabled) %>
+    <%= f.text_area :content, :class => "form-control", :maxlength => "8000", :style => "height:200px;", :value => @ancientexte, :id => "MathInput", :oninput => "PreviewSafe.MyUpdate()", :disabled => (current_user.other || form_disabled) %>
   <% end %>
   <script>initAndUpdatePreviewSafeWhenPossible()</script>
   <script>initLeavingFormWhenPossible()</script>

--- a/app/views/theories/_form.html.erb
+++ b/app/views/theories/_form.html.erb
@@ -9,6 +9,6 @@
   <%= f.label :content, :for => "MathInput", :class => "form-label" %>
   <%= render 'shared/preview' %>
   <%= render 'shared/font' %>
-  <%= f.text_area :content, :class => "form-control", :maxlength => "16000", :style => "height:250px;", :id => "MathInput", :onkeyup => "Preview.MyUpdate()" %>
+  <%= f.text_area :content, :class => "form-control", :maxlength => "16000", :style => "height:250px;", :id => "MathInput", :oninput => "Preview.MyUpdate()" %>
   <script>initAndUpdatePreviewWhenPossible()</script>
 </div>

--- a/app/views/theories/_show.html.erb
+++ b/app/views/theories/_show.html.erb
@@ -1,6 +1,6 @@
 <h3><%= theory.title %></h3>
 <div>
-<%= raw(htmlise(theory.content).gsub(/\/latextest\//, '<div class="mb-2"><div class="card text-bg-ld-light-dark"><div class="card-body" id="MathPreview"></div><div class="card-body hidden-preview" id="MathBuffer"></div></div><textarea id="MathInput" class="form-control mt-2" style="height:120px;" onkeyup="PreviewSafe.Update()" placeholder="Rentrez ici le code $\LaTeX$ que vous souhaitez tester."></textarea></div><script>initAndUpdatePreviewSafeWhenPossible(true)</script>') )%>
+<%= raw(htmlise(theory.content).gsub(/\/latextest\//, '<div class="mb-2"><div class="card text-bg-ld-light-dark"><div class="card-body" id="MathPreview"></div><div class="card-body hidden-preview" id="MathBuffer"></div></div><textarea id="MathInput" class="form-control mt-2" style="height:120px;" oninput="PreviewSafe.Update()" placeholder="Rentrez ici le code $\LaTeX$ que vous souhaitez tester."></textarea></div><script>initAndUpdatePreviewSafeWhenPossible(true)</script>') )%>
 </div>
 
 <div class="noprint">


### PR DESCRIPTION
This fixes the bug where accepting a spell-check suggestion didn't refresh the preview, reported by M.C. on this [forum post](https://www.mathraining.be/subjects/14?page=70).