### PR TITLE
New subject query param

### DIFF
--- a/app/views/subjects/index.html.erb
+++ b/app/views/subjects/index.html.erb
@@ -93,7 +93,7 @@
 
 <!-- Créer un sujet -->
 <center>
-  <%= button_to "Créer un sujet", new_subject_path(:q => @q), method: :get, class: 'btn btn-lg btn-ld-light-dark' %>
+  <%= button_to "Créer un sujet", new_subject_path, params: { q: @q }, method: :get, class: 'btn btn-lg btn-ld-light-dark' %>
 </center>
 
 <!-- Modifier les catégories -->


### PR DESCRIPTION
Quand on cliquait sur "Créer un sujet", [le paramètre `q` n'était pas passé à la nouvelle page, donc le sujet n'était pas présélectionné](https://github.com/user-attachments/assets/3fc54d9b-e5ca-4b6a-8a5e-e8826697b641).

Cela résout le problème en passant le paramètre comme `<input type='hidden'/>`. 

