### PR TITLE
Add overflow-x: auto for the chapter content

### DIFF
--- a/app/assets/stylesheets/common/overflow.scss
+++ b/app/assets/stylesheets/common/overflow.scss
@@ -1,7 +1,11 @@
 .myoverflow {
-  overflow-y:hidden;
+  overflow-y: hidden;
 }
 
 .card-body {
-  overflow-x:auto;
+  overflow-x: auto;
+}
+
+.overflow-x-auto {
+  overflow-x: auto;
 }

--- a/app/assets/stylesheets/common/overflow.scss
+++ b/app/assets/stylesheets/common/overflow.scss
@@ -5,7 +5,3 @@
 .card-body {
   overflow-x: auto;
 }
-
-.overflow-x-auto {
-  overflow-x: auto;
-}

--- a/app/views/chapters/show.html.erb
+++ b/app/views/chapters/show.html.erb
@@ -128,7 +128,7 @@
     <% end %>
   </div>
     
-  <div class="g-col-12 g-col-md-9 g-col-xl-10">
+  <div class="g-col-12 g-col-md-9 g-col-xl-10 overflow-x-auto">
   
     <div class="mt-3 d-md-none"></div>
 

--- a/app/views/chapters/show.html.erb
+++ b/app/views/chapters/show.html.erb
@@ -128,7 +128,7 @@
     <% end %>
   </div>
     
-  <div class="g-col-12 g-col-md-9 g-col-xl-10 overflow-x-auto">
+  <div class="g-col-12 g-col-md-9 g-col-xl-10" style="overflow-x: auto;">
   
     <div class="mt-3 d-md-none"></div>
 


### PR DESCRIPTION
J'ai fais ça comme solution temporaire au problème d'overflow sur les chapitres. Au moins, comme ça le header et la liste "général, points théoriques, exercices" restera à la bonne taille et n'aura pas d'overflow, comme reporté par [Iskandar sur le forum](https://www.mathraining.be/subjects/14?page=73)