### PR TITLE
Add button to hide inactive correctors.

### DIFF
--- a/app/assets/stylesheets/common/corrector.scss
+++ b/app/assets/stylesheets/common/corrector.scss
@@ -1,6 +1,0 @@
-/* CORRECTEURS */
-
-.inactive-corrector {
-  display:none;
-}
-

--- a/app/views/users/correctors.html.erb
+++ b/app/views/users/correctors.html.erb
@@ -271,7 +271,7 @@ Votre navigateur ne supporte pas les canvas.
 <script type="text/javascript">
 const showInactiveCorrectors = () => {
   if ("$" in window) {
-    $('.inactive-corrector').removeClass('inactive-corrector');
+    $('[data-active-corrector="false"]').removeClass('d-none');
     document.getElementById("link_show_inactive").style.display = 'none';
     document.getElementById("link_hide_inactive").style.display = 'block';
   }

--- a/app/views/users/correctors.html.erb
+++ b/app/views/users/correctors.html.erb
@@ -279,7 +279,7 @@ const showInactiveCorrectors = () => {
 
 const hideInactiveCorrectors = () => {
   if ("$" in window) {
-    $('[data-active-corrector="false"]').addClass('inactive-corrector');
+    $('[data-active-corrector="false"]').addClass('d-none');
     document.getElementById("link_show_inactive").style.display = 'block';
     document.getElementById("link_hide_inactive").style.display = 'none';
   }

--- a/app/views/users/correctors.html.erb
+++ b/app/views/users/correctors.html.erb
@@ -307,11 +307,11 @@ const hideInactiveCorrectors = () => {
 <% correctors.sort_by{|e| -e[:nb_corrections]}.each do |c| %>
   <% u = c[:user] %>
   <% green_class = "line-green-#{([c[:nb_recent], 200].min/2).to_i}" %>
-  <% limit = Rails.env.production? ? 30 : 8 %>
-  <% is_active = c[:nb_recent] >= limit ? true : false %>
+  <% limit = Rails.env.production? ? 30 : 1 %>
+  <% is_active = (c[:nb_recent] >= limit) %>
   <% real_rank = rank if c[:nb_corrections] != prev_nb_corrections %>
 
-  <tr class="<%= green_class %> <%= is_active ? "" : "inactive-corrector" %>" data-active-corrector="<%= is_active %>">
+  <tr class="<%= green_class %> <%= is_active ? "" : "d-none" %>" data-active-corrector="<%= is_active %>">
   <td class="text-center"><%= real_rank %>.</td>
   <td><%= raw(u.linked_name) %></td>
   <td class="text-center"><%= c[:nb_corrections] %></td>

--- a/app/views/users/correctors.html.erb
+++ b/app/views/users/correctors.html.erb
@@ -269,10 +269,19 @@ Votre navigateur ne supporte pas les canvas.
 
 
 <script type="text/javascript">
-var showInactiveCorrectors = function () {
+const showInactiveCorrectors = () => {
   if ("$" in window) {
     $('.inactive-corrector').removeClass('inactive-corrector');
     document.getElementById("link_show_inactive").style.display = 'none';
+    document.getElementById("link_hide_inactive").style.display = 'block';
+  }
+}
+
+const hideInactiveCorrectors = () => {
+  if ("$" in window) {
+    $('[data-active-corrector="false"]').addClass('inactive-corrector');
+    document.getElementById("link_show_inactive").style.display = 'block';
+    document.getElementById("link_hide_inactive").style.display = 'none';
   }
 }
 </script>
@@ -298,10 +307,11 @@ var showInactiveCorrectors = function () {
 <% correctors.sort_by{|e| -e[:nb_corrections]}.each do |c| %>
   <% u = c[:user] %>
   <% green_class = "line-green-#{([c[:nb_recent], 200].min/2).to_i}" %>
-  <% limit = Rails.env.production? ? 30 : 1 %>
-  <% inactive_class = (c[:nb_recent] >= limit ? "" : "inactive-corrector") %>
+  <% limit = Rails.env.production? ? 30 : 8 %>
+  <% is_active = c[:nb_recent] >= limit ? true : false %>
   <% real_rank = rank if c[:nb_corrections] != prev_nb_corrections %>
-  <tr class="<%= green_class %> <%= inactive_class %>">
+
+  <tr class="<%= green_class %> <%= is_active ? "" : "inactive-corrector" %>" data-active-corrector="<%= is_active %>">
   <td class="text-center"><%= real_rank %>.</td>
   <td><%= raw(u.linked_name) %></td>
   <td class="text-center"><%= c[:nb_corrections] %></td>
@@ -310,9 +320,10 @@ var showInactiveCorrectors = function () {
   <td class="d-none d-md-table-cell"><%= write_date_only(c[:last_correction].in_time_zone) %></td>
   </tr>
   <% prev_nb_corrections = c[:nb_corrections] %>
-  <% rank = rank+1 %>
+  <% rank += 1 %>
 <% end %>
 </table>
 
 <a id="link_show_inactive" href="javascript:showInactiveCorrectors()">Montrer les correcteurs moins actifs récemment</a>
+<a id="link_hide_inactive" href="javascript:hideInactiveCorrectors()" style="display: none;">Cacher les correcteurs moins actifs récemment</a>
 </center>


### PR DESCRIPTION
Ce PR règle le problème suivant : dans la page `corrections`, à la section "Correcteurs", quand on cliquait sur le bouton "_Montrer les correcteurs moins actifs récemment_", le seul moyen de l'annuler était de recharger la page. Avec ce PR, il y aurait juste un bouton pour cacher les correcteurs moins actifs.