### PR TITLE
Decouple subject and first message in database

### DIFF
--- a/app/controllers/contestproblems_controller.rb
+++ b/app/controllers/contestproblems_controller.rb
@@ -218,10 +218,7 @@ class ContestproblemsController < ApplicationController
   def automatic_results_published_post(contestproblem)
     contest = contestproblem.contest
     sub = contest.subject
-    mes = Message.create(:subject => sub, :user_id => 0, :content => helpers.get_new_correction_forum_message(contest, contestproblem))
-    sub.update(:last_comment_time    => mes.created_at,
-               :last_comment_user_id => 0) # Automatic message
-    
+    Message.create(:subject => sub, :user_id => 0, :content => helpers.get_new_correction_forum_message(contest, contestproblem))    
     sub.following_users.each do |u|
       UserMailer.new_followed_message(u.id, sub.id, -1).deliver
     end

--- a/app/controllers/contests_controller.rb
+++ b/app/controllers/contests_controller.rb
@@ -198,12 +198,11 @@ class ContestsController < ApplicationController
 
   # Helper method to create the forum subject for a contest
   def create_forum_subject(contest)
-    s = Subject.create(:contest              => contest,
-                       :user_id              => 0,
-                       :title                => "Concours ##{contest.number}",
-                       :content              => helpers.get_new_contest_forum_message(contest),
-                       :last_comment_time    => DateTime.now,
-                       :last_comment_user_id => 0,
-                       :category             => Category.where(:name => "Mathraining").first)
+    s = Subject.create(:contest  => contest,
+                       :title    => "Concours ##{contest.number}",
+                       :category => Category.where(:name => "Mathraining").first)
+    Message.create(:subject => s,
+                   :user_id => 0,
+                   :content => helpers.get_new_contest_forum_message(contest))
   end
 end

--- a/app/controllers/corrections_controller.rb
+++ b/app/controllers/corrections_controller.rb
@@ -155,10 +155,6 @@ class CorrectionsController < ApplicationController
       @submission.followings.update_all(:read => false)
     end
 
-    # Change the value of last_comment_time
-    @submission.last_comment_time = @correction.created_at
-    @submission.save
-
     flash[:success] = "Réponse postée#{m}."
     redirect_to problem_path(@problem, :sub => @submission)
   end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -57,9 +57,6 @@ class MessagesController < ApplicationController
       end
     end
 
-    @subject.update(:last_comment_time => DateTime.now,
-                    :last_comment_user => current_user.sk)
-
     if current_user.sk.root?
       if params.has_key?("emailWepion")
         User.where(:group => ["A", "B"]).each do |u|
@@ -99,15 +96,6 @@ class MessagesController < ApplicationController
     subject = @message.subject
     page = @message.page
     @message.destroy
-
-    if subject.messages.count > 0
-      last = subject.messages.order("created_at").last
-      subject.update(:last_comment_time    => last.created_at,
-                     :last_comment_user_id => last.user_id)
-    else
-      subject.update(:last_comment_time    => subject.created_at,
-                     :last_comment_user_id => subject.user_id)
-    end
     
     page = [1,page-1].max if (subject.messages.count <= (page-1) * 10) # if last message is destroyed and it was alone on its page
     redirect_to subject_path(subject, :page => page, :q => @q)

--- a/app/controllers/myfiles_controller.rb
+++ b/app/controllers/myfiles_controller.rb
@@ -20,8 +20,6 @@ class MyfilesController < ApplicationController
       redirect_to problem_path(about.problem, :sub => about)
     elsif type == "Correction"
       redirect_to problem_path(about.submission.problem, :sub => about.submission)
-    elsif type == "Subject"
-      redirect_to about
     elsif type == "Message"
       redirect_to subject_path(about.subject, :page => about.page, :msg => about.id)
     elsif type == "Contestsolution"
@@ -38,12 +36,7 @@ class MyfilesController < ApplicationController
     @fakething = @myfile.fake_del
     flash[:success] = "Contenu de la pièce jointe supprimé."
 
-    if @fakething.fakefiletable_type == "Subject"
-      @subject = @fakething.fakefiletable
-      @q = "all"
-      @q = params[:q] if params.has_key?:q
-      redirect_to subject_path(@subject, :q => @q)
-    elsif @fakething.fakefiletable_type == "Message"
+    if @fakething.fakefiletable_type == "Message"
       @message = @fakething.fakefiletable
       @q = "all"
       @q = params[:q] if params.has_key?:q
@@ -80,34 +73,5 @@ class MyfilesController < ApplicationController
     @myfile = Myfile.find_by_id(params[:myfile_id])
     return if check_nil_object(@myfile)
   end
-  
-  ########## CHECK METHODS ##########
-
-  # Check we have access to the file
-  # Not used anymore with ActiveStorage, but maybe we should still use it in some way?
-  #def have_access
-  #  type = @myfile.myfiletable_type
-  #  if type == "Subject" || type == "Message"
-  #    # Only admins and correctors can see corrector subjects - Only admins and wepion students can see wepion subjects
-  #    subject = (type == "Subject" ? @myfile.myfiletable : @myfile.myfiletable.subject)
-  #    redirect_to root_path if ((!current_user.sk.admin? && !current_user.sk.corrector?) && subject.for_correctors) || ((!current_user.sk.admin? && !current_user.sk.wepion?) && subject.for_wepion)
-  #  elsif type == "Tchatmessage"
-  #    # Only roots and participants to the discussion
-  #    tchatmessage = @myfile.myfiletable
-  #    redirect_to root_path if (!current_user.sk.root? && !current_user.sk.discussions.include?(tchatmessage.discussion))
-  #  elsif type == "Submission" || type == "Correction"
-  #    # Only admins, submission user, correctors having solved the problem, and users having solved the problem (if submission is correct)
-  #    submission = (type == "Submission" ? @myfile.myfiletable : @myfile.myfiletable.submission)
-  #    redirect_to root_path unless (current_user.sk.admin? || current_user.sk == submission.user || current_user.sk.pb_solved?(submission.problem) && (current_user.sk.corrector? || submission.correct?))
-  #  elsif type == "Contestsolution" || type == "Contestcorrection"
-  #    # Only organizers and solution user, or anybody if corrections are finished (status >= :corrected) and solution has 7
-  #    # Only exception is that the solution user cannot see the correction if it is not published yet (status <= :in_correction)
-  #    contestsolution = (type == "Contestsolution" ? @myfile.myfiletable : @myfile.myfiletable.contestsolution)
-  #    contestproblem = contestsolution.contestproblem
-  #    contest = contestproblem.contest
-  #    redirect_to root_path unless (contest.is_organized_by_or_root(current_user.sk) || contestsolution.user == current_user.sk || (contestproblem.at_least(:corrected) && contestsolution.score == 7))
-  #    redirect_to root_path if (type == "Contestcorrection" && contestsolution.user == current_user.sk && contestproblem.at_most(:in_correction))
-  #  end
-  #end
 
 end

--- a/app/controllers/subjects_controller.rb
+++ b/app/controllers/subjects_controller.rb
@@ -4,15 +4,13 @@ class SubjectsController < ApplicationController
   
   before_action :signed_in_user, only: [:index, :show, :new, :unfollow]
   before_action :signed_in_user_danger, only: [:create, :update, :destroy, :migrate, :follow]
-  before_action :admin_user, only: [:destroy, :migrate]
+  before_action :admin_user, only: [:destroy, :update, :migrate]
   before_action :notskin_user, only: [:create, :update]
   
   before_action :get_subject, only: [:show, :update, :destroy]
   before_action :get_subject2, only: [:migrate, :follow, :unfollow]
   
   before_action :user_that_can_see_subject, only: [:show, :follow]
-  before_action :user_that_can_update_subject, only: [:update, :destroy]
-  
   
   before_action :get_q, only: [:index, :show, :new, :create, :update, :destroy, :migrate]
   
@@ -71,20 +69,20 @@ class SubjectsController < ApplicationController
     end
     
     if search_category >= 0
-      @importants = Subject.where(important: true,  for_correctors: correctors_allowed_values, for_wepion: wepion_allowed_values, category: search_category).order("last_comment_time DESC").includes(:user, :last_comment_user, :category, :section, :chapter)
-      @subjects   = Subject.where(important: false, for_correctors: correctors_allowed_values, for_wepion: wepion_allowed_values, category: search_category).order("last_comment_time DESC").paginate(:page => params[:page], :per_page => 15).includes(:user, :last_comment_user, :category, :section, :chapter)
+      @importants = Subject.where(important: true,  for_correctors: correctors_allowed_values, for_wepion: wepion_allowed_values, category: search_category).order("last_comment_time DESC").includes(:last_comment_user, :category, :section, :chapter)
+      @subjects   = Subject.where(important: false, for_correctors: correctors_allowed_values, for_wepion: wepion_allowed_values, category: search_category).order("last_comment_time DESC").paginate(:page => params[:page], :per_page => 15).includes(:last_comment_user, :category, :section, :chapter)
     elsif search_section >= 0
-      @importants = Subject.where(important: true,  for_correctors: correctors_allowed_values, for_wepion: wepion_allowed_values, section: search_section).order("last_comment_time DESC").includes(:user, :last_comment_user, :category, :section, :chapter)
-      @subjects   = Subject.where(important: false, for_correctors: correctors_allowed_values, for_wepion: wepion_allowed_values, section: search_section).order("last_comment_time DESC").paginate(:page => params[:page], :per_page => 15).includes(:user, :last_comment_user, :category, :section, :chapter)
+      @importants = Subject.where(important: true,  for_correctors: correctors_allowed_values, for_wepion: wepion_allowed_values, section: search_section).order("last_comment_time DESC").includes(:last_comment_user, :category, :section, :chapter)
+      @subjects   = Subject.where(important: false, for_correctors: correctors_allowed_values, for_wepion: wepion_allowed_values, section: search_section).order("last_comment_time DESC").paginate(:page => params[:page], :per_page => 15).includes(:last_comment_user, :category, :section, :chapter)
     elsif search_section_problems >= 0
-      @importants = Subject.where(important: true,  for_correctors: correctors_allowed_values, for_wepion: wepion_allowed_values, section: search_section_problems).where.not(problem_id: nil).order("last_comment_time DESC").includes(:user, :last_comment_user, :category, :section, :chapter)
-      @subjects   = Subject.where(important: false, for_correctors: correctors_allowed_values, for_wepion: wepion_allowed_values, section: search_section_problems).where.not(problem_id: nil).order("last_comment_time DESC").paginate(:page => params[:page], :per_page => 15).includes(:user, :last_comment_user, :category, :section, :chapter)
+      @importants = Subject.where(important: true,  for_correctors: correctors_allowed_values, for_wepion: wepion_allowed_values, section: search_section_problems).where.not(problem_id: nil).order("last_comment_time DESC").includes(:last_comment_user, :category, :section, :chapter)
+      @subjects   = Subject.where(important: false, for_correctors: correctors_allowed_values, for_wepion: wepion_allowed_values, section: search_section_problems).where.not(problem_id: nil).order("last_comment_time DESC").paginate(:page => params[:page], :per_page => 15).includes(:last_comment_user, :category, :section, :chapter)
     elsif search_chapter >= 0
-      @importants = Subject.where(important: true,  for_correctors: correctors_allowed_values, for_wepion: wepion_allowed_values, chapter: search_chapter).order("last_comment_time DESC").includes(:user, :last_comment_user, :category, :section, :chapter)
-      @subjects   = Subject.where(important: false, for_correctors: correctors_allowed_values, for_wepion: wepion_allowed_values, chapter: search_chapter).order("last_comment_time DESC").paginate(:page => params[:page], :per_page => 15).includes(:user, :last_comment_user, :category, :section, :chapter)
+      @importants = Subject.where(important: true,  for_correctors: correctors_allowed_values, for_wepion: wepion_allowed_values, chapter: search_chapter).order("last_comment_time DESC").includes(:last_comment_user, :category, :section, :chapter)
+      @subjects   = Subject.where(important: false, for_correctors: correctors_allowed_values, for_wepion: wepion_allowed_values, chapter: search_chapter).order("last_comment_time DESC").paginate(:page => params[:page], :per_page => 15).includes(:last_comment_user, :category, :section, :chapter)
     else # Search nothing
-      @importants = Subject.where(important: true,  for_correctors: correctors_allowed_values, for_wepion: wepion_allowed_values).order("last_comment_time DESC").includes(:user, :last_comment_user, :category, :section, :chapter)
-      @subjects   = Subject.where(important: false, for_correctors: correctors_allowed_values, for_wepion: wepion_allowed_values).order("last_comment_time DESC").paginate(:page => params[:page], :per_page => 15).includes(:user, :last_comment_user, :category, :section, :chapter)
+      @importants = Subject.where(important: true,  for_correctors: correctors_allowed_values, for_wepion: wepion_allowed_values).order("last_comment_time DESC").includes(:last_comment_user, :category, :section, :chapter)
+      @subjects   = Subject.where(important: false, for_correctors: correctors_allowed_values, for_wepion: wepion_allowed_values).order("last_comment_time DESC").paginate(:page => params[:page], :per_page => 15).includes(:last_comment_user, :category, :section, :chapter)
     end
   end
 
@@ -108,14 +106,13 @@ class SubjectsController < ApplicationController
   def create    
     params[:subject][:title].strip! if !params[:subject][:title].nil?
     params[:subject][:content].strip! if !params[:subject][:content].nil?
-    allowed_params = [:title, :content]
+    allowed_params = [:title]
     allowed_params << :for_correctors if (current_user.sk.corrector? || current_user.sk.admin?)
     allowed_params << :important if current_user.sk.admin?
     allowed_params << :for_wepion if (current_user.sk.wepion? || current_user.sk.admin?)
     @subject = Subject.new(params.require(:subject).permit(allowed_params))
-    @subject.user = current_user.sk
-    @subject.last_comment_time = DateTime.now
-    @subject.last_comment_user = current_user.sk
+    @message = Message.new(content: params[:subject][:content])
+    @message.user = current_user.sk
     
     @subject.for_wepion = false if @subject.for_correctors # We don't allow Wépion if for correctors
 
@@ -132,14 +129,19 @@ class SubjectsController < ApplicationController
     
     # Invalid subject
     error_create(@subject.errors.full_messages) and return if !@subject.valid?
+    
+    # Invalid message
+    error_create(@message.errors.full_messages) and return if !@message.valid?
 
     # Attached files
     attach = create_files
     error_create([@file_error]) and return if !@file_error.nil?
 
     @subject.save
+    @message.subject_id = @subject.id
+    @message.save
     
-    attach_files(attach, @subject)
+    attach_files(attach, @message)
 
     if current_user.sk.root?
       if params.has_key?("emailWepion")
@@ -156,15 +158,16 @@ class SubjectsController < ApplicationController
   # Update a subject (send the form)
   def update    
     params[:subject][:title].strip! if !params[:subject][:title].nil?
-    params[:subject][:content].strip! if !params[:subject][:content].nil?
     @subject.title = params[:subject][:title]
-    @subject.title = @subject.title.slice(0,1).capitalize + @subject.title.slice(1..-1)
-    @subject.content = params[:subject][:content]
     @subject.for_correctors = params[:subject][:for_correctors] if !params[:subject][:for_correctors].nil? && (current_user.sk.corrector? || current_user.sk.admin?)
     @subject.important = params[:subject][:important] if !params[:subject][:important].nil? && current_user.sk.admin?
     @subject.for_wepion = params[:subject][:for_wepion] if !params[:subject][:for_wepion].nil? && (current_user.sk.wepion? || current_user.sk.admin?)
     
     @subject.for_wepion = false if @subject.for_correctors # We don't allow Wépion if for correctors
+    
+    if @subject.title.size > 0
+      @subject.title = @subject.title.slice(0,1).capitalize + @subject.title.slice(1..-1)
+    end
     
     # Invalid CSRF token
     error_update([get_csrf_error_message]) and return if @invalid_csrf_token
@@ -175,10 +178,6 @@ class SubjectsController < ApplicationController
     # Set associated object (category, section, chapter, exercise, problem)
     err = set_associated_object
     error_update([err]) and return if !err.empty?
-
-    # Attached files
-    update_files(@subject)
-    error_update([@file_error]) and return if !@file_error.nil?
       
     @subject.save
     
@@ -203,34 +202,18 @@ class SubjectsController < ApplicationController
       redirect_to @subject and return
     end
 
-    if @migreur.created_at > @subject.created_at
-      flash[:danger] = "Le sujet le plus récent doit être migré vers le sujet le moins récent."
-      redirect_to @subject and return
-    end
-    
-    premier_message = Message.create(:content    => @subject.content + "\n\n[i][u]Remarque[/u] : Ce message faisait partie d'un autre sujet appelé '#{@subject.title}' et a été migré ici par un administrateur.[/i]",
-                                     :created_at => @subject.created_at,
-                                     :user       => @subject.user,
-                                     :subject    => @migreur)
-
-    @subject.myfiles.each do |f|
-      f.update_attribute(:myfiletable, premier_message)
-    end
-
-    @subject.fakefiles.each do |f|
-      f.update_attribute(:fakefiletable, premier_message)
-    end
-
-    @subject.messages.each do |m|
+    first_message = true
+    @subject.messages.order(:created_at).each do |m|
+      if first_message
+        m.update_attribute(:content, m.content + "\n\n[i][u]Remarque[/u] : Ce message faisait partie d'un autre sujet appelé '#{@subject.title}' et a été migré ici par un administrateur.[/i]")
+        first_message = false
+      end
       m.update_attribute(:subject, @migreur)
     end
+    
+    @migreur.update_last_comment
 
-    if @subject.last_comment_time > @migreur.last_comment_time
-      @migreur.update(:last_comment_time    => @subject.last_comment_time,
-                      :last_comment_user_id => @subject.last_comment_user_id)
-    end
-
-    @subject.reload # Important because otherwise the "destroy" below also destroys the old messages and files of the subject
+    @subject.reload # Important because otherwise the "destroy" below also destroys the old messages of the subject
     @subject.destroy
 
     redirect_to subject_path(@migreur, :q => @q)
@@ -273,16 +256,7 @@ class SubjectsController < ApplicationController
     @q = params[:q] if params.has_key?:q
     @q = nil if @q == "all" # avoid q = "all" when there is no filter
   end
-  
-  ########## CHECK METHODS ##########
 
-  # Check that current user can update the subject
-  def user_that_can_update_subject
-    unless @subject.can_be_updated_by(current_user.sk)
-      render 'errors/access_refused' and return
-    end
-  end
-  
   ########## HELPER METHODS ##########
   
   # Helper method to set the object associated to a subject

--- a/app/controllers/subjects_controller.rb
+++ b/app/controllers/subjects_controller.rb
@@ -181,7 +181,7 @@ class SubjectsController < ApplicationController
       
     @subject.save
     
-    flash[:success] = "Votre sujet a bien été modifié."
+    flash[:success] = "Le sujet a bien été modifié."
     redirect_to subject_path(@subject, :q => @q, :msg => 0)
   end
 

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -45,8 +45,7 @@ class SubmissionsController < ApplicationController
     params[:submission][:content].strip! if !params[:submission][:content].nil?
 
     @submission = @problem.submissions.build(content: params[:submission][:content],
-                                             user:    current_user.sk,
-                                             last_comment_time: DateTime.now)
+                                             user:    current_user.sk)
     
     # Invalid CSRF token
     render_with_error('problems/show', @submission, get_csrf_error_message) and return if @invalid_csrf_token
@@ -90,8 +89,7 @@ class SubmissionsController < ApplicationController
     @submission = @problem.submissions.build(content: params[:submission][:content],
                                              user:    current_user.sk,
                                              intest:  true,
-                                             visible: false,
-                                             last_comment_time: DateTime.now)
+                                             visible: false)
     
     # Invalid CSRF token
     render_with_error('virtualtests/show', @submission, get_csrf_error_message) and return if @invalid_csrf_token

--- a/app/controllers/suspicions_controller.rb
+++ b/app/controllers/suspicions_controller.rb
@@ -66,7 +66,7 @@ class SuspicionsController < ApplicationController
         if @submission.suspicions.where(:status => :confirmed).count == 0
           @submission.status = (@submission.corrections.where("user_id != ?", @submission.user).count == 0 ? :waiting : :wrong)
           last_comment = @submission.corrections.order(:id).last
-          @submission.update_attribute(:last_comment_time, (last_comment.nil? ? @submission.created_at : last_comment.created_at))
+          @submission.update_last_comment
           if @submission.waiting?
             # Delete the 'following' that was added automatically when submission was marked as plagiarized
             @submission.followings.destroy_all

--- a/app/javascript/custom/rolling.js
+++ b/app/javascript/custom/rolling.js
@@ -25,11 +25,13 @@ var Rolling = {
       var body = $('body,html');
       var yyy = document.getElementById("form" + m).offsetTop - 60;
       body.animate({scrollTop:yyy}, this.rollingTime/2);
-      PreviewSafe.Init(m);
-      if (!enableHiddenText) {
-        PreviewSafe.SetHiddenText(false);
+      if (document.getElementById("MathInput" + m)) {
+        PreviewSafe.Init(m);
+        if (!enableHiddenText) {
+          PreviewSafe.SetHiddenText(false);
+        }
+        PreviewSafe.Update();
       }
-      PreviewSafe.Update();
     });
     return false;
   },
@@ -42,11 +44,13 @@ var Rolling = {
     MathJax.Hub.Queue(function () {
       var yyy = document.getElementById("form" + m).offsetTop - 60;
       body.scrollTop(yyy);
-      PreviewSafe.Init(m);
-      if (!enableHiddenText) {
-        PreviewSafe.SetHiddenText(false);
+      if (document.getElementById("MathInput" + m)) {
+        PreviewSafe.Init(m);
+        if (!enableHiddenText) {
+          PreviewSafe.SetHiddenText(false);
+        }
+        PreviewSafe.Update();
       }
-      PreviewSafe.Update();
     });
   },
 

--- a/app/models/contest.rb
+++ b/app/models/contest.rb
@@ -212,10 +212,6 @@ class Contest < ActiveRecord::Base
     sub = contest.subject
     mes = Message.create(:subject => sub, :user_id => 0, :content => get_problems_in_one_day_forum_message(contest, contestproblems), :created_at => contestproblems[0].start_time - 1.day + (contestproblems[0].number).seconds)
     
-    if mes.created_at > sub.last_comment_time # Security: should always be true
-      sub.update(last_comment_time: mes.created_at, last_comment_user_id: 0)
-    end
-    
     sub.following_users.each do |u|
       if !contest.following_users.include?(u) # Avoid to send again an email to people already following the contest
         UserMailer.new_followed_message(u.id, sub.id, -1).deliver
@@ -228,10 +224,6 @@ class Contest < ActiveRecord::Base
     contest = contestproblems[0].contest
     sub = contest.subject
     mes = Message.create(:subject => sub, :user_id => 0, :content => get_problems_now_forum_message(contest, contestproblems), :created_at => contestproblems[0].start_time + (contestproblems[0].number).seconds)
-    
-    if mes.created_at > sub.last_comment_time # Security: should always be true
-      sub.update(last_comment_time: mes.created_at, last_comment_user_id: 0)
-    end
     
     sub.following_users.each do |u|
       UserMailer.new_followed_message(u.id, sub.id, -1).deliver

--- a/app/models/correction.rb
+++ b/app/models/correction.rb
@@ -22,5 +22,9 @@ class Correction < ActiveRecord::Base
   # VALIDATIONS
 
   validates :content, presence: true, length: { maximum: 16000 } # Limited to 8000 in the form but end-of-lines count twice
+  
+  # BEFORE, AFTER
+  
+  after_create { self.submission.update_last_comment }
 
 end

--- a/app/models/solvedquestion.rb
+++ b/app/models/solvedquestion.rb
@@ -94,21 +94,14 @@ class Solvedquestion < ActiveRecord::Base
       
       subject = Subject.where(:subject_type => :corrector_alerts).first
       if subject.nil?
-        Subject.create(:user_id              => 0,
-                       :title                => "Comptes suspects",
-                       :content              => forum_message,
-                       :for_correctors       => true,
-                       :subject_type         => :corrector_alerts,
-                       :last_comment_time    => DateTime.now,
-                       :last_comment_user_id => 0,
-                       :category             => Category.where(:name => "Mathraining").first)
-      else
-        m = Message.create(:user_id    => 0,
-                           :subject_id => subject.id,
-                           :content    => forum_message)
-        subject.update(:last_comment_time => m.created_at,
-                       :last_comment_user_id => 0)
+        subject = Subject.create(:title          => "Comptes suspects",
+                                 :for_correctors => true,
+                                 :subject_type   => :corrector_alerts,
+                                 :category       => Category.where(:name => "Mathraining").first)
       end
+      Message.create(:user_id    => 0,
+                     :subject_id => subject.id,
+                     :content    => forum_message)
     end
   end
 

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -42,6 +42,7 @@ class Submission < ActiveRecord::Base
   
   # BEFORE, AFTER
   
+  after_create :update_last_comment
   before_destroy { self.notified_users.clear }
 
   # VALIDATIONS
@@ -91,6 +92,16 @@ class Submission < ActiveRecord::Base
     return true  if self.correct?                    # One can see all other correct submissions (if he solved the problem)
     return true  if user.corrector? && self.visible? # Corrector can see all visible submissions (if he solved the problem)
     return false
+  end
+  
+  # Update last_comment_time and last_comment_user
+  def update_last_comment
+    last_correction = self.corrections.order(:created_at).last
+    if last_correction.nil?
+      self.update(:last_comment_time => self.created_at)
+    else
+      self.update(:last_comment_time => last_correction.created_at)
+    end
   end
   
   # Mark the submission as wrong

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -99,7 +99,6 @@ class User < ActiveRecord::Base
   has_many :starproposals, dependent: :destroy
   has_many :followings, dependent: :destroy
   has_many :followed_submissions, through: :followings, source: :submission
-  has_many :subjects, dependent: :destroy
   has_many :messages, dependent: :destroy
   has_many :takentests, dependent: :destroy
   

--- a/app/views/myfiles/index.html.erb
+++ b/app/views/myfiles/index.html.erb
@@ -62,7 +62,7 @@
   <td class="d-none d-lg-table-cell">
   <% if about.nil? %>
     <span class="text-color-red;">Erreur</span>
-  <% elsif type == "Subject" || type == "Message" %>
+  <% elsif type == "Message" %>
     Forum
   <% elsif type == "Submission" && about.draft? %>
     Brouillon

--- a/app/views/shared/_post.html.erb
+++ b/app/views/shared/_post.html.erb
@@ -38,10 +38,10 @@
   <!-- Contenu du message -->
   <div class="content">
   
-  <% theid = -ms.id if kind == "subject" || kind == "submission" || kind == "contestsolution" || kind == "submission_in_test" %>
+  <% theid = -ms.id if kind == "submission" || kind == "contestsolution" || kind == "submission_in_test" %>
   <% theid = ms.id if kind == "message" || kind == "correction" || kind == "contestcorrection" %>
   
-  <%= render '/shared/text_show_hide_code', content: ms.content, id: theid, replace_indice: (kind == "subject" || kind == "message") %>
+  <%= render '/shared/text_show_hide_code', content: ms.content, id: theid, replace_indice: (kind == "message") %>
   
   <!-- Pièces jointes -->
   <%= render 'shared/show_files', s: ms %>  
@@ -49,21 +49,7 @@
   
   <% if can_edit %>
     <div class="modify">
-      <% if kind == "subject" %>
-        <a href='#' onclick='return Rolling.develop("<%= postfix %>", true)'>Modifier ce sujet</a>
-        <% if current_user.sk.admin? %>
-          | <%= link_to "Supprimer ce sujet", subject_path(ms), method: :delete, data: { confirm: "Êtes-vous sûr de vouloir supprimer ce sujet et tous les messages associés ?" }  %>
-          | <a href='#' id='showform' onclick='document.getElementById("migration_form").style.display="inline"; return false;' style='display:inline;'>Migrer ce sujet</a>
-          <span id='migration_form' style="<%= 'display:none;' if !Rails.env.test? %>">
-          <%= form_tag subject_migrate_path(ms), :method => :put, :class => "mt-1" do %>
-            Migrer ce sujet vers le sujet numéro
-            <%= hidden_field_tag "q", @q %>
-            <%= number_field_tag "migreur", nil, min: 1, max: 10000, style: "width:80px;" %>
-            <%= submit_tag "Migrer", data: { confirm: "Êtes-vous sûr de vouloir migrer ce sujet ? Êtes-vous sûr de l'id du sujet receveur ?"} %>
-          <% end %>
-          </span>
-        <% end %>
-      <% elsif kind == "message" %>
+      <% if kind == "message" %>
         <a href='#' onclick='return Rolling.develop("<%= postfix %>", true)' id='LinkEdit<%= postfix %>'>Modifier ce message</a>
         <% if current_user.sk.admin? %>
            | <%= link_to "Supprimer ce message", message_path(ms), method: :delete, id: "LinkDelete#{ postfix }", data: { confirm: "Êtes-vous sûr de vouloir supprimer ce message ?" }  %>

--- a/app/views/subjects/_edit.html.erb
+++ b/app/views/subjects/_edit.html.erb
@@ -1,7 +1,6 @@
 <!-- Formulaire -->
 <%= form_for @subject, :url => subject_path(@subject, :action => :update, :q => @q), :html => { :multipart => true, :class => "mt-2" } do |f| %>
   <%= render 'subjects/form', f: f, postfix: postfix, is_edit: true %>
-  <%= render 'shared/edit_files', s: @subject, postfix: postfix %>
   <%= f.submit "Modifier", id: "Submit#{ postfix }", class: "btn btn-lg btn-primary", :disabled => current_user.other %>
   <button class="btn btn-lg btn-ld-light-dark" onclick="return Rolling.hideActual();">Annuler</button>
 <% end %>

--- a/app/views/subjects/_form.html.erb
+++ b/app/views/subjects/_form.html.erb
@@ -285,23 +285,19 @@ function checkWepion() {
 <% end %>
 
 <!-- Message -->
-<div class="mb-2">
-  <% cont = "" %>
-  <% if erreur %>
-    <% cont = @error_params[:content] if @error_params.has_key?(:content) %>
-  <% elsif is_edit %>
-    <% cont = @subject.content %>
-  <% end %>
-  <%= f.label :content, :for => "MathInput#{postfix}", :class => "form-label", :disabled => current_user.other %>
-  <%= render 'shared/preview', postfix: postfix %>
-  <%= render 'shared/smiley', postfix: postfix, hiddentext: true %>
-  <%= f.text_area :content, :class => "form-control", :maxlength => "8000", :style => "height:200px;", :id=>"MathInput#{postfix}", :oninput => "PreviewSafe.MyUpdate()", :disabled => current_user.other, :value => cont %>
-  <% if is_edit %>
-    <!-- Do not call initAndUpdatePreviewSafeWhenPossible(): it will be done only after rolling to show the form -->
-  <% else %>
+<% unless is_edit %>
+  <div class="mb-2">
+    <% cont = "" %>
+    <% if erreur %>
+      <% cont = @error_params[:content] if @error_params.has_key?(:content) %>
+    <% end %>
+    <%= f.label :content, :for => "MathInput#{postfix}", :class => "form-label", :disabled => current_user.other %>
+    <%= render 'shared/preview', postfix: postfix %>
+    <%= render 'shared/smiley', postfix: postfix, hiddentext: true %>
+    <%= f.text_area :content, :class => "form-control", :maxlength => "8000", :style => "height:200px;", :id=>"MathInput#{postfix}", :oninput => "PreviewSafe.MyUpdate()", :disabled => current_user.other, :value => cont %>
     <script>initAndUpdatePreviewSafeWhenPossible(false, true)</script>
-  <% end %>
-</div>
+  </div>
+<% end %>
 
 <!-- Case correcteurs -->
 <% if current_user.sk.admin || current_user.sk.corrector %>

--- a/app/views/subjects/_line.html.erb
+++ b/app/views/subjects/_line.html.erb
@@ -51,7 +51,11 @@
   <!-- Date du dernier message -->
   <td class="d-none d-lg-table-cell align-middle text-center" style="width:220px;">
     <%= link_to subject_path(s, :page => "last", :q => @q) do %>
-      <%= write_date_from_now(date, datenow) %>
+      <% if date.nil? %>
+        ---
+      <% else %>   
+        <%= write_date_from_now(date, datenow) %>
+      <% end %> 
     <% end %>
   </td>
 

--- a/app/views/subjects/_subject.html.erb
+++ b/app/views/subjects/_subject.html.erb
@@ -1,7 +1,5 @@
 <% postfix = "EditSubject" %>
 
-<% can_edit = s.can_be_updated_by(current_user.sk) %>
-
 <div id="the<%= postfix %>" class="myoverflow">
 
 <% if !@subject.question.nil? %>
@@ -12,11 +10,25 @@
   <%= render 'subjects/contest', contest: @subject.contest %>
 <% end %>
 
-<%= render 'shared/post', ms: s, kind: "subject", can_edit: can_edit, postfix: postfix %>
+<% if current_user.sk.admin? %>
+  <div class="mt-2 text-center">
+    <a href="#" onclick='return Rolling.develop("<%= postfix %>", true)'>Modifier ce sujet</a>
+    | <%= link_to "Supprimer ce sujet", subject_path(@subject), method: :delete, data: { confirm: "Êtes-vous sûr de vouloir supprimer ce sujet et tous les messages associés ?" }  %>
+    | <a href='#' id='showform' onclick='document.getElementById("migration_form").style.display="inline"; return false;' style='display:inline;'>Migrer ce sujet</a>
+      <span id='migration_form' style="<%= 'display:none;' if !Rails.env.test? %>">
+      <%= form_tag subject_migrate_path(@subject), :method => :put, :class => "mt-1" do %>
+        Migrer ce sujet vers le sujet numéro
+        <%= hidden_field_tag "q", @q %>
+        <%= number_field_tag "migreur", nil, min: 1, max: 10000, style: "width:80px;" %>
+        <%= submit_tag "Migrer", data: { confirm: "Êtes-vous sûr de vouloir migrer ce sujet ? Êtes-vous sûr de l'id du sujet receveur ?"} %>
+      <% end %>
+      </span>
+  </div>
+<% end %>
 
 </div>
 
-<% if can_edit %>
+<% if current_user.sk.admin? %>
   <div id="form<%= postfix %>" class="myoverflow px-1" style="height:0px;">
   <%= render 'subjects/edit', s: s, postfix: postfix %>
   </div>

--- a/app/views/subjects/index.html.erb
+++ b/app/views/subjects/index.html.erb
@@ -62,7 +62,7 @@
       <th class="d-table-cell d-lg-none text-center">Dernière contribution</th>
     </tr>
     <% @importants.each do |s| %>
-      <%= render 'line', s: s, num_messages: (num_messages_by_subject.has_key?(s.id) ? num_messages_by_subject[s.id] : 0) %>
+      <%= render 'line', s: s, num_messages: (num_messages_by_subject.has_key?(s.id) ? num_messages_by_subject[s.id] - 1 : 0) %>
     <% end %>
   </table>
 <% end %>
@@ -77,7 +77,7 @@
       <th class="d-table-cell d-lg-none text-center">Dernière contribution</th>
     </tr>
     <% @subjects.each do |s| %>
-      <%= render 'line', s: s, num_messages: (num_messages_by_subject.has_key?(s.id) ? num_messages_by_subject[s.id] : 0) %>
+      <%= render 'line', s: s, num_messages: (num_messages_by_subject.has_key?(s.id) ? num_messages_by_subject[s.id] - 1 : 0) %>
     <% end %>
   </table>
 <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -976,7 +976,7 @@
       <%= link_to "Supprimer les données personnelles", user_destroydata_path(@user), data: { confirm: "ATTENTION : Cette action va supprimer les données personnelles de #{@user.name}, à savoir son adresse e-mail et son nom. Êtes-vous sûr de vouloir continuer ?" }, :method => :put, :class => "text-color-red" %>
       <%= " | " if i > 0 %>
       <% i = i+1 %>
-      <%= link_to 'Supprimer', @user, method: :delete, data: { confirm: "ATTENTION : Privilégiez la suppression des données personnelles ! En continuant, vous supprimerez toutes les données relatives à ce compte. Notez que cet utilisateur a ouvert #{@user.subjects.count} sujet(s) et a écrit #{@user.messages.count} message(s) sur le forum, tout sera supprimé ! Êtes-vous sûr de vouloir supprimer #{@user.name} ?" }, :class => "text-color-red" %>
+      <%= link_to 'Supprimer', @user, method: :delete, data: { confirm: "ATTENTION : Privilégiez la suppression des données personnelles ! En continuant, vous supprimerez toutes les données relatives à ce compte. Notez que cet utilisateur a écrit #{@user.messages.count} message(s) sur le forum, tout sera supprimé ! Êtes-vous sûr de vouloir supprimer #{@user.name} ?" }, :class => "text-color-red" %>
     <% end %>
     <% if current_user.sk.root? && @user.email_confirm && !@user.admin %>
       <%= " | " if i > 0 %>

--- a/db/migrate/20241007193855_decouple_subject_and_first_message.rb
+++ b/db/migrate/20241007193855_decouple_subject_and_first_message.rb
@@ -1,0 +1,49 @@
+class DecoupleSubjectAndFirstMessage < ActiveRecord::Migration[7.0]
+  def up
+    execute("INSERT INTO messages (content, subject_id, user_id, created_at) SELECT content, id, user_id, created_at FROM subjects;")
+    
+    Myfile.where(:myfiletable_type => "Subject").each do |f|
+      s = Subject.find(f.myfiletable_id)
+      f.update_attribute(:myfiletable, s.messages.order(:created_at).first)
+    end
+    
+    Fakefile.where(:fakefiletable_type => "Subject").each do |f|
+      s = Subject.find(f.fakefiletable_id)
+      f.update_attribute(:fakefiletable, s.messages.order(:created_at).first)
+    end
+  
+    remove_column :subjects, :content, :text
+    remove_column :subjects, :user_id, :integer
+    remove_column :subjects, :created_at, :datetime
+  end
+  
+  def down
+    add_column :subjects, :content, :text
+    add_column :subjects, :user_id, :integer
+    add_column :subjects, :created_at, :datetime, precision: nil
+    
+    Myfile.where(:myfiletable_type => "Message").each do |f|
+      m = Message.find(f.myfiletable_id)
+      s = m.subject
+      if s.messages.order(:created_at).first == m
+        f.update(:myfiletable_type => "Subject", :myfiletable_id => s.id)
+      end
+    end
+    
+    Fakefile.where(:fakefiletable_type => "Message").each do |f|
+      m = Message.find(f.fakefiletable_id)
+      s = m.subject
+      if s.messages.order(:created_at).first == m
+        f.update(:fakefiletable_type => "Subject", :fakefiletable_id => s.id)
+      end
+    end
+    
+    Subject.all.each do |s|
+      m = s.messages.order(:created_at).first
+      unless m.nil?
+        s.update(:content => m.content, :user_id => m.user_id, :created_at => m.created_at)
+        m.destroy
+      end
+    end
+  end
+end

--- a/spec/controllers/myfiles_controller_spec.rb
+++ b/spec/controllers/myfiles_controller_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 describe MyfilesController, type: :controller, myfile: true do
 
   let(:admin) { FactoryGirl.create(:admin) }
-  let(:myfile) { FactoryGirl.create(:subjectmyfile) }
+  let(:myfile) { FactoryGirl.create(:messagemyfile) }
   
   context "if the user is not a root" do
     before do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -136,9 +136,6 @@ FactoryGirl.define do
   
   # Myfile
   factory :myfile do
-    factory :subjectmyfile do
-      association :myfiletable, factory: :subject
-    end
     factory :messagemyfile do
       association :myfiletable, factory: :message
     end
@@ -262,10 +259,6 @@ FactoryGirl.define do
   # Subject
   factory :subject do
     sequence(:title) { |n| "Titre #{n}" }
-    sequence(:content) { |n| "Contenu #{n}" }
-    association :user
-    last_comment_time DateTime.now
-    association :last_comment_user, :factory => :user
     association :category
     chapter_id nil
     section_id nil
@@ -283,7 +276,6 @@ FactoryGirl.define do
     association :problem
     association :user
     sequence(:content) { |n| "Interesting submission #{n}" }
-    last_comment_time DateTime.now
   end
   
   # Suspicion

--- a/spec/models/OLD/subject_spec.rb
+++ b/spec/models/OLD/subject_spec.rb
@@ -4,10 +4,7 @@
 #
 #  id                   :integer          not null, primary key
 #  title                :string
-#  content              :text
-#  user_id              :integer
 #  chapter_id           :integer
-#  created_at           :datetime         not null
 #  last_comment_time    :datetime
 #  for_correctors       :boolean          default(FALSE)
 #  important            :boolean          default(FALSE)
@@ -29,8 +26,6 @@ describe Subject do
   subject { @s }
 
   it { should respond_to(:title) }
-  it { should respond_to(:content) }
-  it { should respond_to(:user) }
   it { should respond_to(:last_comment_time) }
   it { should respond_to(:for_correctors) }
   it { should respond_to(:important) }
@@ -43,18 +38,4 @@ describe Subject do
     before { @s.title = nil }
     it { should_not be_valid }
   end
-  
-  # Content
-  describe "when content is not present" do
-    before { @s.content = nil }
-    it { should_not be_valid }
-  end
-
-  # User
-  describe "when user is not present" do
-    before { @s.user = nil }
-    it { should_not be_valid }
-  end
-
-
 end

--- a/spec/requests/OLD/solvedquestion_pages_spec.rb
+++ b/spec/requests/OLD/solvedquestion_pages_spec.rb
@@ -396,18 +396,18 @@ describe "Solvedquestion pages" do
       end
       specify do
         expect(Subject.where(:subject_type => :corrector_alerts).count).to eq(1)
-        expect(Subject.last.user_id).to eq(0)
-        expect(Subject.last.content).to include(cheater.name)
-        expect(Subject.last.content).to include("a résolu 6 exercices en 3 minutes et 8 exercices en 10 minutes")
-        expect(Subject.last.content).to include("Il a résolu 10 exercices après moins d'une minute de réflexion, dont un en 5 secondes")
-        expect(Subject.last.messages.count).to eq(0) # No message for the moment
+        expect(Subject.last.messages.count).to eq(1)
+        expect(Subject.last.messages.last.user_id).to eq(0)
+        expect(Subject.last.messages.last.content).to include(cheater.name)
+        expect(Subject.last.messages.last.content).to include("a résolu 6 exercices en 3 minutes et 8 exercices en 10 minutes")
+        expect(Subject.last.messages.last.content).to include("Il a résolu 10 exercices après moins d'une minute de réflexion, dont un en 5 secondes")
       end
       
       describe "and searches a second time" do
         before { Solvedquestion.detect_suspicious_users }
         specify do
           expect(Subject.where(:subject_type => :corrector_alerts).count).to eq(1)
-          expect(Subject.last.messages.count).to eq(1)
+          expect(Subject.last.messages.count).to eq(2)
           expect(Message.last.user_id).to eq (0)
           expect(Message.last.content).to include(cheater.name)
           expect(Message.last.content).to include("a résolu 6 exercices en 3 minutes et 8 exercices en 10 minutes")

--- a/spec/requests/OLD/subject_pages_spec.rb
+++ b/spec/requests/OLD/subject_pages_spec.rb
@@ -253,7 +253,7 @@ describe "Subject pages" do
         specify do
           expect(sub.title).to eq(newtitle)
           expect(sub.category).to eq(category2)
-          expect(page).to have_success_message("Votre sujet a bien été modifié.")
+          expect(page).to have_success_message("Le sujet a bien été modifié.")
           expect(page).to have_content("#{newtitle} - #{category2.name}")
         end
       end
@@ -600,7 +600,7 @@ describe "Subject pages" do
         sub_question.reload
       end
       specify do
-        expect(page).to have_success_message("Votre sujet a bien été modifié.")
+        expect(page).to have_success_message("Le sujet a bien été modifié.")
         expect(sub_question.title).to eq(newtitle)
         expect(sub_question.section).to eq(other_section)
         expect(sub_question.chapter).to eq(nil)
@@ -623,7 +623,7 @@ describe "Subject pages" do
         sub_category.reload
       end
       specify do
-        expect(page).to have_success_message("Votre sujet a bien été modifié.")
+        expect(page).to have_success_message("Le sujet a bien été modifié.")
         expect(sub_category.title).to eq(newtitle)
         expect(sub_category.section).to eq(section)
         expect(sub_category.chapter).to eq(other_chapter)
@@ -646,7 +646,7 @@ describe "Subject pages" do
         sub_chapter.reload
       end
       specify do
-        expect(page).to have_success_message("Votre sujet a bien été modifié.")
+        expect(page).to have_success_message("Le sujet a bien été modifié.")
         expect(sub_chapter.title).to eq("Exercice 1")
         expect(sub_chapter.section).to eq(section)
         expect(sub_chapter.chapter).to eq(other_chapter)
@@ -669,7 +669,7 @@ describe "Subject pages" do
         sub_chapter.reload
       end
       specify do
-        expect(page).to have_success_message("Votre sujet a bien été modifié.")
+        expect(page).to have_success_message("Le sujet a bien été modifié.")
         expect(sub_chapter.title).to eq("Problème \##{other_problem.number}")
         expect(sub_chapter.section).to eq(section)
         expect(sub_chapter.chapter).to eq(nil)

--- a/spec/requests/OLD/submission_pages_spec.rb
+++ b/spec/requests/OLD/submission_pages_spec.rb
@@ -116,7 +116,8 @@ describe "Submission pages" do
         
         describe "and sends new submission while another one was recently plagiarized" do # Can only be done with several tabs
           before do
-            FactoryGirl.create(:submission, problem: problem, user: user, status: :plagiarized, last_comment_time: DateTime.now - 3.months)
+            plagiarism = FactoryGirl.create(:submission, problem: problem, user: user, status: :plagiarized)
+            plagiarism.update_attribute(:last_comment_time, DateTime.now - 3.months)
             fill_in "MathInput", with: newsubmission
             click_button "Soumettre cette solution"
           end
@@ -131,7 +132,8 @@ describe "Submission pages" do
         
         describe "and sends new submission while another one was plagiarized long ago" do
           before do
-            FactoryGirl.create(:submission, problem: problem, user: user, status: :plagiarized, last_comment_time: DateTime.now - 2.years)
+            plagiarism = FactoryGirl.create(:submission, problem: problem, user: user, status: :plagiarized)
+            plagiarism.update_attribute(:last_comment_time, DateTime.now - 2.years)
             fill_in "MathInput", with: newsubmission
             click_button "Soumettre cette solution"
           end
@@ -146,7 +148,8 @@ describe "Submission pages" do
         
         describe "and sends new submission while another one was recently closed" do # Can only be done with several tabs
           before do
-            FactoryGirl.create(:submission, problem: problem, user: user, status: :closed, last_comment_time: DateTime.now - 3.days)
+            closed = FactoryGirl.create(:submission, problem: problem, user: user, status: :closed)
+            closed.update_attribute(:last_comment_time, DateTime.now - 3.days)
             fill_in "MathInput", with: newsubmission
             click_button "Soumettre cette solution"
           end
@@ -161,7 +164,8 @@ describe "Submission pages" do
         
         describe "and sends new submission while another one was closed long ago" do
           before do
-            FactoryGirl.create(:submission, problem: problem, user: user, status: :closed, last_comment_time: DateTime.now - 2.weeks)
+            closed = FactoryGirl.create(:submission, problem: problem, user: user, status: :closed)
+            closed.update_attribute(:last_comment_time, DateTime.now - 2.weeks)
             fill_in "MathInput", with: newsubmission
             click_button "Soumettre cette solution"
           end

--- a/spec/requests/OLD/user_pages_spec.rb
+++ b/spec/requests/OLD/user_pages_spec.rb
@@ -604,12 +604,10 @@ describe "User pages" do
     end
     
     describe "deletes a student with some created stuffs" do
-      let!(:sub) { FactoryGirl.create(:subject, user: zero_user) }
-      let!(:mes) { FactoryGirl.create(:message, subject: sub, user: other_zero_user) }
-      let!(:mes2) { FactoryGirl.create(:message, user: zero_user) }
+      let!(:mes) { FactoryGirl.create(:message, user: zero_user) }
       let!(:disc) { create_discussion_between(zero_user, other_zero_user, "Coucou mon ami", "Salut mon poto") }
       before { visit user_path(zero_user) }
-      specify { expect { click_link "Supprimer" }.to change(User, :count).by(-1) .and change(Subject, :count).by(-1) .and change(Message, :count).by(-2) .and change(Discussion, :count).by(-1) .and change(Link, :count).by(-2) .and change(Tchatmessage, :count).by(-2) }
+      specify { expect { click_link "Supprimer" }.to change(User, :count).by(-1) .and change(Subject, :count).by(0) .and change(Message, :count).by(-1) .and change(Discussion, :count).by(-1) .and change(Link, :count).by(-2) .and change(Tchatmessage, :count).by(-2) }
     end
 
     describe "deletes a student while a root has his skin" do

--- a/spec/requests/contestcorrection_pages_spec.rb
+++ b/spec/requests/contestcorrection_pages_spec.rb
@@ -16,7 +16,7 @@ describe "Contestcorrection pages", contestcorrection: true do
   let!(:user_organizer) { FactoryGirl.create(:advanced_user) }
   
   let!(:contest) { FactoryGirl.create(:contest, status: :in_progress) }
-  let!(:contestsubject) { FactoryGirl.create(:subject, contest: contest, user_id: 0) }
+  let!(:contestsubject) { FactoryGirl.create(:subject, contest: contest) }
   
   let!(:contestproblem_finished) { FactoryGirl.create(:contestproblem, contest: contest, number: 1, start_time: datetime_before, end_time: datetime_before2, status: :in_correction) }
   

--- a/spec/requests/message_pages_spec.rb
+++ b/spec/requests/message_pages_spec.rb
@@ -239,5 +239,29 @@ describe "Message pages", message: true do
         expect(mes_user.myfiles.second.file.filename.to_s).to eq(image2)
       end
     end
+    
+    describe "modifies a message with a fake file" do
+      let!(:messagemyfile) { FactoryGirl.create(:messagemyfile, myfiletable: mes_user) }
+      before do
+        messagemyfile.fake_del
+        visit subject_path(sub)
+        wait_for_js_imports
+        click_link("LinkEditMessage#{mes_user.id}")
+        wait_for_ajax
+        fill_in "MathInputMessage#{mes_user.id}", with: content2
+        uncheck "prevFakeFileMessage#{mes_user.id}_#{Fakefile.order(:id).last.id}"
+        click_button "addFileMessage#{mes_user.id}" # Ajouter une pièce jointe
+        wait_for_ajax
+        attach_file("fileMessage#{mes_user.id}_1", File.absolute_path(attachments_folder + image2))
+        click_button "Modifier"
+        mes_user.reload
+      end
+      specify do
+        expect(mes_user.content).to eq(content2)
+        expect(mes_user.fakefiles.count).to eq(0)
+        expect(mes_user.myfiles.count).to eq(1)
+        expect(mes_user.myfiles.first.file.filename.to_s).to eq(image2)
+      end
+    end
   end
 end

--- a/spec/requests/myfile_pages_spec.rb
+++ b/spec/requests/myfile_pages_spec.rb
@@ -23,7 +23,6 @@ describe "Myfile pages", myfile: true do
   let(:discussion) { create_discussion_between(root, user, "Bonjour", "Salut") }
   let(:tchatmessage) { discussion.tchatmessages.first }
   
-  let(:subjectmyfile) { FactoryGirl.create(:subjectmyfile, myfiletable: sub) }
   let(:messagemyfile) { FactoryGirl.create(:messagemyfile, myfiletable: message) }
   let(:submissionmyfile) { FactoryGirl.create(:submissionmyfile, myfiletable: submission) }
   let(:correctionmyfile) { FactoryGirl.create(:correctionmyfile, myfiletable: correction) }
@@ -40,39 +39,12 @@ describe "Myfile pages", myfile: true do
     before { sign_in root }
     
     describe "visits all files page" do
-      let!(:subjectmyfile) { FactoryGirl.create(:subjectmyfile, myfiletable: sub) } # Force its creation
+      let!(:messagemyfile) { FactoryGirl.create(:messagemyfile, myfiletable: message) } # Force its creation
       before { visit myfiles_path }
       it do
         should have_selector("h1", text: "Pièces jointes")
-        should have_link("Voir", href: myfile_path(subjectmyfile))
-        should have_link(href: rails_blob_url(subjectmyfile.file, :only_path => true, :disposition => 'attachment'))
-      end
-    end
-    
-    describe "visits one subject file" do
-      before { visit myfile_path(subjectmyfile) }
-      it do
-        should have_current_path(subject_path(sub))
-        should have_link(subjectmyfile.file.filename.to_s, href: rails_blob_url(subjectmyfile.file, :only_path => true, :disposition => 'attachment'))
-        should have_link("Supprimer le contenu", href: myfile_fake_delete_path(subjectmyfile))
-      end
-      
-      describe "and fake deletes it" do
-        before { click_link("Supprimer le contenu", href: myfile_fake_delete_path(subjectmyfile)) }
-        it do
-          should have_current_path(subject_path(sub, :q => "all"))
-          should have_success_message("Contenu de la pièce jointe supprimé.")
-          should have_content("désactivée")
-        end
-      end
-      
-      describe "and fake deletes it while it was deleted by someone else" do
-        before do
-          id = subjectmyfile.id
-          subjectmyfile.destroy
-          click_link("Supprimer le contenu", href: myfile_fake_delete_path(id))
-        end
-        it { should have_content(error_access_refused) }
+        should have_link("Voir", href: myfile_path(messagemyfile))
+        should have_link(href: rails_blob_url(messagemyfile.file, :only_path => true, :disposition => 'attachment'))
       end
     end
     

--- a/spec/views/layouts/_header.html.erb_spec.rb
+++ b/spec/views/layouts/_header.html.erb_spec.rb
@@ -132,7 +132,12 @@ describe "layouts/_header.html.erb", type: :view, layout: true do
     
     context "and has some forum messages to read" do
       let!(:subject) { FactoryGirl.create(:subject) }
-      let!(:old_subject) { FactoryGirl.create(:subject, last_comment_time: DateTime.now - 3.days) }
+      let!(:message) { FactoryGirl.create(:message, subject: subject) }
+      let!(:old_subject) { FactoryGirl.create(:subject) }
+      let!(:old_message) { FactoryGirl.create(:message, subject: old_subject, created_at: DateTime.now - 3.days) }
+      before do
+        user.update_attribute(:last_forum_visit_time, DateTime.now - 1.day)
+      end
       
       it "renders the number of unread forum messages correctly" do
         render partial: "layouts/header"


### PR DESCRIPTION
Dorénavant, un Subject ne contient plus le contenu du message, l'utilisateur ayant créé le sujet et la date de création. À la place, un premier message est automatiquement créé avec ces données lors de la création du sujet.

De cette manière, tous les messages du Forum sont logés à la même enseigne et il n'y a plus besoin de traiter le premier message séparément. Cela permet de supprimer pas mal de code. Cela résout aussi quelques incohérences, par exemple la première page de chaque sujet de Forum qui contenait 11 messages au lieu de 10. Cela permettra aussi de supprimer le premier message d'un sujet sans supprimer le sujet tout entier, si besoin.

Grâce à cela, il sera plus facile d'implémenter la possibilité pour un utilisateur de supprimer son message.