### PR TITLE
Only display "modifier ce message" is it hasn't been soft deleted

### DIFF
--- a/app/views/shared/_post.html.erb
+++ b/app/views/shared/_post.html.erb
@@ -58,9 +58,7 @@
           | <%= link_to "Supprimer ce message", message_soft_destroy_path(ms), method: :put, id: "LinkSoftDelete#{ postfix }", data: { confirm: "Êtes-vous sûr de vouloir supprimer ce message ?" } %>
         <% end %>
         <% if current_user.sk.admin? %>
-          <% unless ms.erased? %>
-            |
-          <% end %>
+          <%= "|" unless ms.erased? %>
           <%= link_to "Supprimer totalement ce message", message_path(ms), method: :delete, id: "LinkDelete#{ postfix }", data: { confirm: "Êtes-vous sûr de vouloir supprimer ce message ?" }  %>
         <% end %>
       <% elsif kind == "contestsolution" %>

--- a/app/views/shared/_post.html.erb
+++ b/app/views/shared/_post.html.erb
@@ -53,12 +53,15 @@
   <% if can_edit %>
     <div class="modify">
       <% if kind == "message" %>
-        <a href='#' onclick='return Rolling.develop("<%= postfix %>", true)' id='LinkEdit<%= postfix %>'>Modifier ce message</a>
         <% unless ms.erased? %>
+          <a href='#' onclick='return Rolling.develop("<%= postfix %>", true)' id='LinkEdit<%= postfix %>'>Modifier ce message</a>
           | <%= link_to "Supprimer ce message", message_soft_destroy_path(ms), method: :put, id: "LinkSoftDelete#{ postfix }", data: { confirm: "Êtes-vous sûr de vouloir supprimer ce message ?" } %>
         <% end %>
         <% if current_user.sk.admin? %>
-           | <%= link_to "Supprimer totalement ce message", message_path(ms), method: :delete, id: "LinkDelete#{ postfix }", data: { confirm: "Êtes-vous sûr de vouloir supprimer ce message ?" }  %>
+          <% unless ms.erased? %>
+            |
+          <% end %>
+          <%= link_to "Supprimer totalement ce message", message_path(ms), method: :delete, id: "LinkDelete#{ postfix }", data: { confirm: "Êtes-vous sûr de vouloir supprimer ce message ?" }  %>
         <% end %>
       <% elsif kind == "contestsolution" %>
         <a href='#' onclick='return Rolling.develop("")'>Modifier la solution</a>


### PR DESCRIPTION
This fixes the bug, where admins were able to edit a message even after if had been soft-deleted. It also makes sure to only render `|` before "Supprimer totalement ce message" if it isn't the only option.