### PR TITLE
Fix populate

### DIFF
--- a/app/controllers/contests_controller.rb
+++ b/app/controllers/contests_controller.rb
@@ -193,11 +193,10 @@ class ContestsController < ApplicationController
 
   # Helper method to create the forum subject for a contest
   def create_forum_subject(contest)
-    Subject.create_with_first_message(
-      user_id: 0,
-      title: "Concours ##{contest.number}",
-      content: helpers.get_new_contest_forum_message(contest),
-      contest: contest,
-      category: Category.where(name: "Mathraining").first)
+    Subject.create_with_first_message(user_id:  0,
+                                      title:    "Concours ##{contest.number}",
+                                      content:  helpers.get_new_contest_forum_message(contest),
+                                      contest:  contest,
+                                      category: Category.where(name: "Mathraining").first)
   end
 end

--- a/app/controllers/contests_controller.rb
+++ b/app/controllers/contests_controller.rb
@@ -198,7 +198,6 @@ class ContestsController < ApplicationController
       title: "Concours ##{contest.number}",
       content: helpers.get_new_contest_forum_message(contest),
       contest: contest,
-      category: Category.where(name: "Mathraining").first,
-      created_at: Time.now)
+      category: Category.where(name: "Mathraining").first)
   end
 end

--- a/app/controllers/contests_controller.rb
+++ b/app/controllers/contests_controller.rb
@@ -193,11 +193,12 @@ class ContestsController < ApplicationController
 
   # Helper method to create the forum subject for a contest
   def create_forum_subject(contest)
-    s = Subject.create(:contest  => contest,
-                       :title    => "Concours ##{contest.number}",
-                       :category => Category.where(:name => "Mathraining").first)
-    Message.create(:subject => s,
-                   :user_id => 0,
-                   :content => helpers.get_new_contest_forum_message(contest))
+    Subject.create_with_first_message(
+      user_id: 0,
+      title: "Concours ##{contest.number}",
+      content: helpers.get_new_contest_forum_message(contest),
+      contest: contest,
+      category: Category.where(name: "Mathraining").first,
+      created_at: Time.now)
   end
 end

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -75,4 +75,22 @@ class Subject < ActiveRecord::Base
                   :last_comment_user_id => last_message.user_id)
     end
   end
+
+  def self.create_with_first_message(user_id:, title:, content:, created_at:, category: nil, contest: nil, important: false, for_wepion: false, question: nil, chapter: nil, section: nil, for_correctors: false)
+    subject = Subject.create(title:             title,
+                             category:          category,
+                             important:         important,
+                             for_wepion:        for_wepion,
+                             question:          question,
+                             chapter:           chapter,
+                             section:           section,
+                             for_correctors:    for_correctors)
+
+    Message.create(subject:    subject,
+                   user_id:    user_id,
+                   content:    content,
+                   created_at: created_at)
+
+    return subject
+  end
 end

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -76,21 +76,9 @@ class Subject < ActiveRecord::Base
     end
   end
 
-  def self.create_with_first_message(user_id:, title:, content:, created_at:, category: nil, contest: nil, important: false, for_wepion: false, question: nil, chapter: nil, section: nil, for_correctors: false)
-    subject = Subject.create(title:             title,
-                             category:          category,
-                             important:         important,
-                             for_wepion:        for_wepion,
-                             question:          question,
-                             chapter:           chapter,
-                             section:           section,
-                             for_correctors:    for_correctors)
-
-    Message.create(subject:    subject,
-                   user_id:    user_id,
-                   content:    content,
-                   created_at: created_at)
-
+  def self.create_with_first_message(user_id:, title:, content:, created_at: Time.now, **options)
+    subject = Subject.create(title: title, **options)
+    Message.create(subject: subject, user_id: user_id, content: content, created_at: created_at)
     return subject
   end
 end

--- a/lib/tasks/sample_data.rake
+++ b/lib/tasks/sample_data.rake
@@ -439,7 +439,7 @@ def create_subjects
   user = User.where(:root => true).first
   time = DateTime.now - 20.days
   category = Category.where(:name => "Mathraining").first
-  subject = Subject.create(user:              user,
+  subject = create_subject(user:              user,
                            title:             "Questions relatives à Mathraining",
                            content:           "Si vous avez la moindre question, n'hésitez pas !",
                            important:         true,
@@ -458,7 +458,7 @@ def create_subjects
   user = User.where(:root => true).first
   time = DateTime.now - 30.days
   category = Category.where(:name => "Wépion").first
-  subject = Subject.create(user:              user,
+  subject = create_subject(user:              user,
                            title:             "Cours 2021-2022",
                            content:           "Voici l'horaire des cours de Wépion pour cette année.",
                            important:         true,
@@ -478,7 +478,7 @@ def create_subjects
   user = User.where(:root => false, :admin => true).first
   time = DateTime.now - 10.days
   category = Category.where(:name => "Mathraining").first
-  subject = Subject.create(user:              user,
+  subject = create_subject(user:              user,
                            title:             "Instructions pour les correcteurs",
                            content:           "Voici les instructions pour les nouveaux correcteurs :-)",
                            important:         true,
@@ -492,7 +492,7 @@ def create_subjects
   user = User.where(:admin => false).first
   time = user.created_at + 2.hours
   chapter = Chapter.first
-  subject = Subject.create(user:              user,
+  subject = create_subject(user:              user,
                            title:             "Hein !?",
                            content:           "Je ne comprends rien à ce chapitre, quelqu'un peut me le réexpliquer en entier ?",
                            section:           chapter.section,
@@ -511,7 +511,7 @@ def create_subjects
   user = User.where(:admin => false).second
   time = user.created_at + 5.hours
   question = Section.where(:fondation => true).first.chapters.first.questions.first
-  subject = Subject.create(user:              user,
+  subject = create_subject(user:              user,
                            title:             "Exercice incorrect ?",
                            content:           "Cet exercice me semble erroné, qu'en pensez-vous ?",
                            section:           question.chapter.section,
@@ -526,6 +526,28 @@ def create_subjects
                            content:    "J'en pense que tu dis des sottises !",
                            created_at: time + 7.hours)
   subject.update(last_comment_time: message.created_at, last_comment_user: message.user)
+end
+
+def create_subject(user:, title:, content:, created_at:, last_comment_time:, last_comment_user:,
+                   category: nil, important: false, for_wepion: false, question: nil, chapter: nil,
+                   section: nil, for_correctors: false)
+  subject = Subject.create(title:             title,
+                           category:          category,
+                           last_comment_time: last_comment_time,
+                           last_comment_user: last_comment_user,
+                           important:         important,
+                           for_wepion:        for_wepion,
+                           question:          question,
+                           chapter:           chapter,
+                           section:           section,
+                           for_correctors:    for_correctors)
+
+  Message.create(subject:    subject,
+                 user:       user,
+                 content:    content,
+                 created_at: created_at)
+
+  subject
 end
 
 # Update some statistics

--- a/lib/tasks/sample_data.rake
+++ b/lib/tasks/sample_data.rake
@@ -527,9 +527,19 @@ def create_subjects
   subject.update(last_comment_time: message.created_at, last_comment_user: message.user)
 end
 
-def create_subject(user:, title:, content:, created_at:, last_comment_time:, last_comment_user:,
-                   category: nil, important: false, for_wepion: false, question: nil, chapter: nil,
-                   section: nil, for_correctors: false)
+def create_subject(user:,
+                   title:,
+                   content:,
+                   created_at:,
+                   last_comment_time:,
+                   last_comment_user:,
+                   category: nil,
+                   important: false,
+                   for_wepion: false,
+                   question: nil,
+                   chapter: nil,
+                   section: nil,
+                   for_correctors: false)
   subject = Subject.create(title:             title,
                            category:          category,
                            last_comment_time: last_comment_time,

--- a/lib/tasks/sample_data.rake
+++ b/lib/tasks/sample_data.rake
@@ -186,30 +186,30 @@ def create_users
   country[2] = Country.where(:name => "Maroc").first
   
   # Root
-  root = User.create(first_name:            "Root",
-                     last_name:             "Root",
-                     email:                 "root@root.com",
-                     email_confirmation:    "root@root.com",
-                     password:              "foobar",
-                     password_confirmation: "foobar",
-                     root:                  true,
-                     admin:                 true,
-                     year:                  1990,
-                     country:               country[0],
-                     created_at:            DateTime.now - 100.days)
+  User.create(first_name:            "Root",
+              last_name:             "Root",
+              email:                 "root@root.com",
+              email_confirmation:    "root@root.com",
+              password:              "foobar",
+              password_confirmation: "foobar",
+              root:                  true,
+              admin:                 true,
+              year:                  1990,
+              country:               country[0],
+              created_at:            DateTime.now - 100.days)
   
   # Admin
-  admin = User.create(first_name:            "Admin",
-                      last_name:             "Admin",
-                      email:                 "admin@admin.com",
-                      email_confirmation:    "admin@admin.com",
-                      password:              "foobar",
-                      password_confirmation: "foobar",
-                      root:                  false,
-                      admin:                 true,
-                      year:                  1993,
-                      country:               country[1],
-                      created_at:            DateTime.now - 90.days)
+  User.create(first_name:            "Admin",
+              last_name:             "Admin",
+              email:                 "admin@admin.com",
+              email_confirmation:    "admin@admin.com",
+              password:              "foobar",
+              password_confirmation: "foobar",
+              root:                  false,
+              admin:                 true,
+              year:                  1993,
+              country:               country[1],
+              created_at:            DateTime.now - 90.days)
                       
   # Students
   for i in 1..20
@@ -223,20 +223,20 @@ def create_users
       group = "A" if x == 1
       group = "B" if x == 2
     end
-    user = User.create(first_name:           "User",
-                       last_name:            "User-" + letter,
-                       email:                 mail,
-                       email_confirmation:    mail,
-                       password:              "foobar",
-                       password_confirmation: "foobar",
-                       root:                  false,
-                       admin:                 false,
-                       year:                  2000 + Random.rand(5),
-                       country:               country[Random.rand(3)],
-                       wepion:                wepion,
-                       group:                 group,
-                       rating:                user_level,
-                       created_at:            DateTime.now - user_level.days)
+    User.create(first_name:           "User",
+                last_name:            "User-" + letter,
+                email:                 mail,
+                email_confirmation:    mail,
+                password:              "foobar",
+                password_confirmation: "foobar",
+                root:                  false,
+                admin:                 false,
+                year:                  2000 + Random.rand(5),
+                country:               country[Random.rand(num_countries)],
+                wepion:                wepion,
+                group:                 group,
+                rating:                user_level,
+                created_at:            DateTime.now - user_level.days)
   end
 end
 
@@ -360,7 +360,6 @@ def create_submissions
         next
       end
       
-      r2 = Random.rand(3)
       is_correct = (Random.rand(3) <= 1)
       submission_time = last_question_solved_time + Random.rand(DateTime.now.to_i - last_question_solved_time.to_i + 1).seconds
       corrected = Random.rand(30) > 0
@@ -560,7 +559,6 @@ end
 
 # Create visitor statistics
 def create_visitor_statistics
-  cur_day = Date.today - 100
   (0..99).each do |x|
     Visitor.create(date:      Date.today - 100 + x,
                    nb_users:  (x/10).to_i + Random.rand(1+(x/10).to_i),

--- a/lib/tasks/sample_data.rake
+++ b/lib/tasks/sample_data.rake
@@ -438,83 +438,79 @@ def create_subjects
   user = User.where(:root => true).first
   time = DateTime.now - 20.days
   category = Category.where(:name => "Mathraining").first
-  subject = Subject.create_with_first_message(user:              user,
-                           title:             "Questions relatives à Mathraining",
-                           content:           "Si vous avez la moindre question, n'hésitez pas !",
-                           important:         true,
-                           category:          category,
-                           created_at:        time)
-  
-  message = Message.create(subject:    subject,
-                           user:       User.where(:admin => false).order(:created_at).last,
-                           content:    "Je me demandais : comment devient-on correcteur ?",
-                           created_at: DateTime.now - 5.days)
-  subject.update(last_comment_time: message.created_at, last_comment_user: message.user)
+  subject = Subject.create_with_first_message(user_id:    user.id,
+                                              title:      "Questions relatives à Mathraining",
+                                              content:    "Si vous avez la moindre question, n'hésitez pas !",
+                                              important:  true,
+                                              category:   category,
+                                              created_at: time)
+
+  Message.create(subject:    subject,
+                 user:       User.where(:admin => false).order(:created_at).last,
+                 content:    "Je me demandais : comment devient-on correcteur ?",
+                 created_at: DateTime.now - 5.days)
   
   # One important subject for Wépion
   user = User.where(:root => true).first
   time = DateTime.now - 30.days
   category = Category.where(:name => "Wépion").first
-  subject = Subject.create_with_first_message(user_id:           user.id,
-                                              title:             "Cours 2021-2022",
-                                              content:           "Voici l'horaire des cours de Wépion pour cette année.",
-                                              important:         true,
-                                              for_wepion:        true,
-                                              category:          category,
-                                              created_at:        time)
+  subject = Subject.create_with_first_message(user_id:    user.id,
+                                              title:      "Cours 2021-2022",
+                                              content:    "Voici l'horaire des cours de Wépion pour cette année.",
+                                              important:  true,
+                                              for_wepion: true,
+                                              category:   category,
+                                              created_at: time)
   
-  message = Message.create(subject:    subject,
-                           user:       User.where(:wepion => true).first,
-                           content:    "Merci pour cette information précieuse.",
-                           created_at: time + 2.hours)
-  subject.update(last_comment_time: message.created_at, last_comment_user: message.user)
+  Message.create(subject:    subject,
+                 user:       User.where(:wepion => true).first,
+                 content:    "Merci pour cette information précieuse.",
+                 created_at: time + 2.hours)
   
   # One important subject for correctors
   user = User.where(:root => false, :admin => true).first
   time = DateTime.now - 10.days
   category = Category.where(:name => "Mathraining").first
-  subject = Subject.create_with_first_message(user_id:           user.id,
-                                              title:             "Instructions pour les correcteurs",
-                                              content:           "Voici les instructions pour les nouveaux correcteurs :-)",
-                                              important:         true,
-                                              for_correctors:    true,
-                                              category:          category,
-                                              created_at:        time)
+  subject = Subject.create_with_first_message(user_id:        user.id,
+                                              title:          "Instructions pour les correcteurs",
+                                              content:        "Voici les instructions pour les nouveaux correcteurs :-)",
+                                              important:      true,
+                                              for_correctors: true,
+                                              category:       category,
+                                              created_at:     time)
                            
   # One subject about a chapter
   user = User.where(:admin => false).first
   time = user.created_at + 2.hours
   chapter = Chapter.first
-  subject = Subject.create_with_first_message(user_id:              user.id,
-                                              title:             "Hein !?",
-                                              content:           "Je ne comprends rien à ce chapitre, quelqu'un peut me le réexpliquer en entier ?",
-                                              section:           chapter.section,
-                                              chapter:           chapter,
-                                              created_at:        time)
+  subject = Subject.create_with_first_message(user_id:    user.id,
+                                              title:      "Hein !?",
+                                              content:    "Je ne comprends rien à ce chapitre, quelqu'un peut me le réexpliquer en entier ?",
+                                              section:    chapter.section,
+                                              chapter:    chapter,
+                                              created_at: time)
   
-  message = Message.create(subject:    subject,
-                           user:       User.where(:admin => true).first,
-                           content:    "Relis le chapitre, tout simplement...",
-                           created_at: time + 2.minutes)
-  subject.update(last_comment_time: message.created_at, last_comment_user: message.user)
+  Message.create(subject:    subject,
+                 user:       User.where(:admin => true).first,
+                 content:    "Relis le chapitre, tout simplement...",
+                 created_at: time + 2.minutes)
   
   # One subject about a question
   user = User.where(:admin => false).second
   time = user.created_at + 5.hours
   question = Section.where(:fondation => true).first.chapters.first.questions.first
-  subject = Subject.create_with_first_message(user_id:              user.id,
-                                              title:             "Exercice incorrect ?",
-                                              content:           "Cet exercice me semble erroné, qu'en pensez-vous ?",
-                                              section:           question.chapter.section,
-                                              chapter:           question.chapter,
-                                              question:          question,
-                                              created_at:        time)
+  subject = Subject.create_with_first_message(user_id:    user.id,
+                                              title:      "Exercice incorrect ?",
+                                              content:    "Cet exercice me semble erroné, qu'en pensez-vous ?",
+                                              section:    question.chapter.section,
+                                              chapter:    question.chapter,
+                                              question:   question,
+                                              created_at: time)
   
-  message = Message.create(subject:    subject,
-                           user:       User.where(:admin => false).third,
-                           content:    "J'en pense que tu dis des sottises !",
-                           created_at: time + 7.hours)
-  subject.update(last_comment_time: message.created_at, last_comment_user: message.user)
+  Message.create(subject:    subject,
+                 user:       User.where(:admin => false).third,
+                 content:    "J'en pense que tu dis des sottises !",
+                 created_at: time + 7.hours)
 end
 
 # Update some statistics

--- a/lib/tasks/sample_data.rake
+++ b/lib/tasks/sample_data.rake
@@ -438,14 +438,12 @@ def create_subjects
   user = User.where(:root => true).first
   time = DateTime.now - 20.days
   category = Category.where(:name => "Mathraining").first
-  subject = create_subject(user:              user,
+  subject = Subject.create_with_first_message(user:              user,
                            title:             "Questions relatives à Mathraining",
                            content:           "Si vous avez la moindre question, n'hésitez pas !",
                            important:         true,
                            category:          category,
-                           created_at:        time,
-                           last_comment_time: time,
-                           last_comment_user: user)
+                           created_at:        time)
   
   message = Message.create(subject:    subject,
                            user:       User.where(:admin => false).order(:created_at).last,
@@ -457,15 +455,13 @@ def create_subjects
   user = User.where(:root => true).first
   time = DateTime.now - 30.days
   category = Category.where(:name => "Wépion").first
-  subject = create_subject(user:              user,
-                           title:             "Cours 2021-2022",
-                           content:           "Voici l'horaire des cours de Wépion pour cette année.",
-                           important:         true,
-                           for_wepion:        true,
-                           category:          category,
-                           created_at:        time,
-                           last_comment_time: time,
-                           last_comment_user: user)
+  subject = Subject.create_with_first_message(user_id:           user.id,
+                                              title:             "Cours 2021-2022",
+                                              content:           "Voici l'horaire des cours de Wépion pour cette année.",
+                                              important:         true,
+                                              for_wepion:        true,
+                                              category:          category,
+                                              created_at:        time)
   
   message = Message.create(subject:    subject,
                            user:       User.where(:wepion => true).first,
@@ -477,28 +473,24 @@ def create_subjects
   user = User.where(:root => false, :admin => true).first
   time = DateTime.now - 10.days
   category = Category.where(:name => "Mathraining").first
-  subject = create_subject(user:              user,
-                           title:             "Instructions pour les correcteurs",
-                           content:           "Voici les instructions pour les nouveaux correcteurs :-)",
-                           important:         true,
-                           for_correctors:    true,
-                           category:          category,
-                           created_at:        time,
-                           last_comment_time: time,
-                           last_comment_user: user)
+  subject = Subject.create_with_first_message(user_id:           user.id,
+                                              title:             "Instructions pour les correcteurs",
+                                              content:           "Voici les instructions pour les nouveaux correcteurs :-)",
+                                              important:         true,
+                                              for_correctors:    true,
+                                              category:          category,
+                                              created_at:        time)
                            
   # One subject about a chapter
   user = User.where(:admin => false).first
   time = user.created_at + 2.hours
   chapter = Chapter.first
-  subject = create_subject(user:              user,
-                           title:             "Hein !?",
-                           content:           "Je ne comprends rien à ce chapitre, quelqu'un peut me le réexpliquer en entier ?",
-                           section:           chapter.section,
-                           chapter:           chapter,
-                           created_at:        time,
-                           last_comment_time: time,
-                           last_comment_user: user)
+  subject = Subject.create_with_first_message(user_id:              user.id,
+                                              title:             "Hein !?",
+                                              content:           "Je ne comprends rien à ce chapitre, quelqu'un peut me le réexpliquer en entier ?",
+                                              section:           chapter.section,
+                                              chapter:           chapter,
+                                              created_at:        time)
   
   message = Message.create(subject:    subject,
                            user:       User.where(:admin => true).first,
@@ -510,53 +502,19 @@ def create_subjects
   user = User.where(:admin => false).second
   time = user.created_at + 5.hours
   question = Section.where(:fondation => true).first.chapters.first.questions.first
-  subject = create_subject(user:              user,
-                           title:             "Exercice incorrect ?",
-                           content:           "Cet exercice me semble erroné, qu'en pensez-vous ?",
-                           section:           question.chapter.section,
-                           chapter:           question.chapter,
-                           question:          question,
-                           created_at:        time,
-                           last_comment_time: time,
-                           last_comment_user: user)
+  subject = Subject.create_with_first_message(user_id:              user.id,
+                                              title:             "Exercice incorrect ?",
+                                              content:           "Cet exercice me semble erroné, qu'en pensez-vous ?",
+                                              section:           question.chapter.section,
+                                              chapter:           question.chapter,
+                                              question:          question,
+                                              created_at:        time)
   
   message = Message.create(subject:    subject,
                            user:       User.where(:admin => false).third,
                            content:    "J'en pense que tu dis des sottises !",
                            created_at: time + 7.hours)
   subject.update(last_comment_time: message.created_at, last_comment_user: message.user)
-end
-
-def create_subject(user:,
-                   title:,
-                   content:,
-                   created_at:,
-                   last_comment_time:,
-                   last_comment_user:,
-                   category: nil,
-                   important: false,
-                   for_wepion: false,
-                   question: nil,
-                   chapter: nil,
-                   section: nil,
-                   for_correctors: false)
-  subject = Subject.create(title:             title,
-                           category:          category,
-                           last_comment_time: last_comment_time,
-                           last_comment_user: last_comment_user,
-                           important:         important,
-                           for_wepion:        for_wepion,
-                           question:          question,
-                           chapter:           chapter,
-                           section:           section,
-                           for_correctors:    for_correctors)
-
-  Message.create(subject:    subject,
-                 user:       user,
-                 content:    content,
-                 created_at: created_at)
-
-  subject
 end
 
 # Update some statistics


### PR DESCRIPTION
La commande `rake db:populate` ne fonctionnait plus à cause du changement de la table `Subject` il y a un mois. Ce pr règle ces problèmes et retire par ailleurs quelques variable qui n'étaient pas utilisées. J'ai essayé de recréér la base et à priori tout fonctionne bien.