### PR TITLE
Add "notranslate" class to logo on header

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -5,7 +5,7 @@
 <nav class="navbar navbar-expand-lg fixed-top bg-body-tertiary">
   <div class="container">
     <!-- Lien Mathraining -->
-    <%= link_to root_path, class: "navbar-brand me-4", style: "font-size:24px;", id: "Accueil" do %>
+    <%= link_to root_path, class: "navbar-brand me-4 notranslate", style: "font-size:24px;", id: "Accueil" do %>
       <span class="text-color-black-white">Math</span><span class="text-color-mt-blue">raining</span>
     <% end %>
     


### PR DESCRIPTION
This (probably) fixes the issue reported by [Mael Shalawy](https://www.mathraining.be/subjects/14?page=81). I couldn't reproduce the bug so I cannot be sure.