### PR TITLE
Remove whitespace between badges in split-title

### DIFF
--- a/app/assets/stylesheets/common/title.scss
+++ b/app/assets/stylesheets/common/title.scss
@@ -19,11 +19,11 @@ $title-breakpoints: lg md;
   }
 
   .split-title-#{$title-breakpoint} .part-2 {
-    text-align: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5em;
     @media (min-width: map-get($grid-breakpoints, '#{$title-breakpoint}')) {
-      text-align: right;
       padding-left: 1em;
     }
   }
-
 }

--- a/app/assets/stylesheets/common/title.scss
+++ b/app/assets/stylesheets/common/title.scss
@@ -21,8 +21,10 @@ $title-breakpoints: lg md;
   .split-title-#{$title-breakpoint} .part-2 {
     display: flex;
     flex-wrap: wrap;
+    justify-content: center;
     gap: 0.5em;
     @media (min-width: map-get($grid-breakpoints, '#{$title-breakpoint}')) {
+      justify-content: flex-end;
       padding-left: 1em;
     }
   }

--- a/app/views/problems/show.html.erb
+++ b/app/views/problems/show.html.erb
@@ -8,7 +8,7 @@
   <div class="part-1">
     <h1><%= title_problems(@problem.section, "Problème&nbsp;##{ @problem.number }#{ (' - Test&nbsp;#' +  @problem.virtualtest.number.to_s ) if @problem.virtualtest_id != 0 } #{ '(en construction)' if !@problem.online }".html_safe) %></h1>
   </div>
-  <div class="part-2">
+  <div class="part-2 mb-2">
     <span class="badge rounded-pill py-2 px-3 <%= problem_solved ? 'bg-success' : 'bg-secondary' %>" style="font-size:18px;"><%= pt %>&nbsp;points</span>
     <% if @problem.online %>
       <span class="badge rounded-pill py-2 px-3 bg-primary" style="font-size:18px;">Résolu <%= @problem.nb_solves %> fois</span>

--- a/app/views/problems/show.html.erb
+++ b/app/views/problems/show.html.erb
@@ -9,9 +9,9 @@
     <h1><%= title_problems(@problem.section, "Problème&nbsp;##{ @problem.number }#{ (' - Test&nbsp;#' +  @problem.virtualtest.number.to_s ) if @problem.virtualtest_id != 0 } #{ '(en construction)' if !@problem.online }".html_safe) %></h1>
   </div>
   <div class="part-2">
-    <span class="badge rounded-pill py-2 px-3 mb-2 <%= problem_solved ? 'bg-success' : 'bg-secondary' %>" style="font-size:18px;"><%= pt %>&nbsp;points</span>
+    <span class="badge rounded-pill py-2 px-3 <%= problem_solved ? 'bg-success' : 'bg-secondary' %>" style="font-size:18px;"><%= pt %>&nbsp;points</span>
     <% if @problem.online %>
-      <span class="badge rounded-pill py-2 px-3 mb-2 bg-primary" style="font-size:18px;">Résolu <%= @problem.nb_solves %> fois</span>
+      <span class="badge rounded-pill py-2 px-3 bg-primary" style="font-size:18px;">Résolu <%= @problem.nb_solves %> fois</span>
     <% end %>
   </div>
 </div>

--- a/app/views/problems/show.html.erb
+++ b/app/views/problems/show.html.erb
@@ -9,9 +9,9 @@
     <h1><%= title_problems(@problem.section, "Problème&nbsp;##{ @problem.number }#{ (' - Test&nbsp;#' +  @problem.virtualtest.number.to_s ) if @problem.virtualtest_id != 0 } #{ '(en construction)' if !@problem.online }".html_safe) %></h1>
   </div>
   <div class="part-2">
-    <span class="badge rounded-pill py-2 px-3 mb-2 ms-1 <%= problem_solved ? 'bg-success' : 'bg-secondary' %>" style="font-size:18px;"><%= pt %>&nbsp;points</span>
+    <span class="badge rounded-pill py-2 px-3 mb-2 <%= problem_solved ? 'bg-success' : 'bg-secondary' %>" style="font-size:18px;"><%= pt %>&nbsp;points</span>
     <% if @problem.online %>
-      <span class="badge rounded-pill py-2 px-3 mb-2 ms-1 bg-primary" style="font-size:18px;">Résolu <%= @problem.nb_solves %> fois</span>
+      <span class="badge rounded-pill py-2 px-3 mb-2 bg-primary" style="font-size:18px;">Résolu <%= @problem.nb_solves %> fois</span>
     <% end %>
   </div>
 </div>

--- a/app/views/questions/_title.html.erb
+++ b/app/views/questions/_title.html.erb
@@ -10,11 +10,11 @@
   </div>
   <div class="part-2">
     <% if !@section.fondation %>
-      <span class="badge rounded-pill py-2 px-3 mb-2 ms-1 <%= solved ? 'bg-success' : 'bg-secondary' %>" style="font-size:18px;"><%= pt %>&nbsp;points</span>
+      <span class="badge rounded-pill py-2 px-3 mb-2 <%= solved ? 'bg-success' : 'bg-secondary' %>" style="font-size:18px;"><%= pt %>&nbsp;points</span>
     <% end %>
     <% if question.online %>
-      <span class="badge rounded-pill py-2 px-3 mb-2 ms-1 bg-primary" style="font-size:18px;">Résolu <%= question.nb_correct %> fois</span>
-      <%= link_to "#{ (100*pct).round(0) }% au 1<sup>er</sup> essai".html_safe, stats_chapters_path, :class => "badge rounded-pill py-2 px-3 mb-2 ms-1 text-color-dark-light-blue gradient-green-red-#{ ((1-pct2)*20).to_i }", :style => "font-size:18px;" %>
+      <span class="badge rounded-pill py-2 px-3 mb-2 bg-primary" style="font-size:18px;">Résolu <%= question.nb_correct %> fois</span>
+      <%= link_to "#{ (100*pct).round(0) }% au 1<sup>er</sup> essai".html_safe, stats_chapters_path, :class => "badge rounded-pill py-2 px-3 mb-2 text-color-dark-light-blue gradient-green-red-#{ ((1-pct2)*20).to_i }", :style => "font-size:18px;" %>
     <% end %>
   </div>
 </div>

--- a/app/views/questions/_title.html.erb
+++ b/app/views/questions/_title.html.erb
@@ -10,11 +10,11 @@
   </div>
   <div class="part-2">
     <% if !@section.fondation %>
-      <span class="badge rounded-pill py-2 px-3 mb-2 <%= solved ? 'bg-success' : 'bg-secondary' %>" style="font-size:18px;"><%= pt %>&nbsp;points</span>
+      <span class="badge rounded-pill py-2 px-3 <%= solved ? 'bg-success' : 'bg-secondary' %>" style="font-size:18px;"><%= pt %>&nbsp;points</span>
     <% end %>
     <% if question.online %>
-      <span class="badge rounded-pill py-2 px-3 mb-2 bg-primary" style="font-size:18px;">Résolu <%= question.nb_correct %> fois</span>
-      <%= link_to "#{ (100*pct).round(0) }% au 1<sup>er</sup> essai".html_safe, stats_chapters_path, :class => "badge rounded-pill py-2 px-3 mb-2 text-color-dark-light-blue gradient-green-red-#{ ((1-pct2)*20).to_i }", :style => "font-size:18px;" %>
+      <span class="badge rounded-pill py-2 px-3 bg-primary" style="font-size:18px;">Résolu <%= question.nb_correct %> fois</span>
+      <%= link_to "#{ (100*pct).round(0) }% au 1<sup>er</sup> essai".html_safe, stats_chapters_path, :class => "badge rounded-pill py-2 px-3 text-color-dark-light-blue gradient-green-red-#{ ((1-pct2)*20).to_i }", :style => "font-size:18px;" %>
     <% end %>
   </div>
 </div>

--- a/app/views/questions/_title.html.erb
+++ b/app/views/questions/_title.html.erb
@@ -8,7 +8,7 @@
   <div class="part-1">
     <h3>Exercice&nbsp;<%= number if question.online? %></h3>
   </div>
-  <div class="part-2">
+  <div class="part-2 mb-2">
     <% if !@section.fondation %>
       <span class="badge rounded-pill py-2 px-3 <%= solved ? 'bg-success' : 'bg-secondary' %>" style="font-size:18px;"><%= pt %>&nbsp;points</span>
     <% end %>


### PR DESCRIPTION
**Motivation :** supprimer le caractère " " entre les infos dans le split-title, pour éviter que l'on puisse le sélectionner comme montré ci-contre.
![Screenshot from 2025-01-18 20-11-40](https://github.com/user-attachments/assets/cab6346d-d175-4066-8831-6dba2ea63016) En bonus, cela permet une meilleure maîtrise de l'espacement.

**Changements :** j'ai mis un `display: flex` sur le parent. Pour compenser l'espace enlevé, j'ai retiré les classes `ms-1` et les ai remplacés par un `gap`.