### PR TITLE
Add `flex-grow: 1` to labels in MCQ to take full width

### DIFF
--- a/app/views/questions/_question_form.html.erb
+++ b/app/views/questions/_question_form.html.erb
@@ -32,7 +32,7 @@
       <% else %>
         <%= radio_button_tag "ans", c.id, prev_answers.include?(c.id), :id => "ans_#{ c.id }", :disabled => !signed_in? || in_skin? || need_to_wait, :class => "form-check-input to-enable flex-shrink-0 my-0" %>
       <% end %>
-      <label for="ans_<%= c.id %>" class="form-check-label">
+      <label for="ans_<%= c.id %>" class="form-check-label flex-grow-1">
         <%= htmlise(c.ans) %>
       </label>
     </div>


### PR DESCRIPTION
J'ai ajouté du flex-grow pour que les `label` prennent toute la largeur lorsque la réponse est cachée. Ceci règle le problème d'affichage différent lorsque la réponse est cachée / affichée. Toutefois, ce commit va agrandir les images utilisées, donc il faudra probablement réduire leur taille par la suite.