### PR TITLE
Fix typo: externalsoltuion -> externalsolution in fr.yml

### DIFF
--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -11,7 +11,7 @@ fr:
       contestsolution: "Solution"
       correction: "Commentaire"
       discussion: "Discussion"
-      externalsoltuion: "Solution externe"
+      externalsolution: "Solution externe"
       extract: "Extrait"
       item: "Choix"
       message: "Message"


### PR DESCRIPTION
## Summary
- Fixes a typo in `config/locales/fr.yml` where the model translation key `externalsoltuion` should be `externalsolution` (matching the `ExternalSolution` model). The mistyped key meant the French translation for this model name was never picked up by Rails i18n.

## Test plan
- [x] Verified the corrected key now matches the model name `externalsolution` used elsewhere in `fr.yml` (attributes section) and in `app/models/externalsolution.rb`.