### PR TITLE
Empêcher la création d'un compte avec une variante d'une adresse e-mail existante

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,6 +37,7 @@
 #  password_strength         :integer          default("unknown_password")
 #  accepted_code_of_conduct  :boolean          default(FALSE)
 #  whitelisted               :boolean          default(FALSE)
+#  canonical_email           :string
 #
 include ERB::Util
 
@@ -147,6 +148,7 @@ class User < ActiveRecord::Base
   # BEFORE, AFTER
 
   before_validation :create_corrector_color
+  before_validation :set_canonical_email
   before_save { self.email.downcase! }
   before_create :create_remember_token
   after_create :create_points
@@ -170,6 +172,7 @@ class User < ActiveRecord::Base
   validates :email, presence: true, format: { with: VALID_EMAIL_REGEX }, uniqueness: { case_sensitive: false }
   validates :email_confirmation, presence: true, on: :create
   validates_confirmation_of :email, case_sensitive: false
+  validate :email_is_not_an_alias_of_an_existing_one # See issue #108
   validates :password, length: { minimum: 8, maximum: 128 }, on: :create
   validates :password, length: { minimum: 8, maximum: 128 }, on: :update, allow_blank: true
   validates_with MyPasswordValidator
@@ -178,7 +181,65 @@ class User < ActiveRecord::Base
   validates_with ColorValidator
   
   # OTHER METHODS
-  
+
+  # ---------------------------------------------------------------------------
+  # E-mail canonicalization (to make double accounts harder, see issue #108)
+  # ---------------------------------------------------------------------------
+  #
+  # Many e-mail providers consider several "spellings" of an address as the very
+  # same mailbox. To make the creation of double accounts harder, we compute a
+  # canonical form of each address (stored in the canonical_email column) and we
+  # forbid a new account whose canonical form is already used by another account.
+  #
+  # The rules below are intentionally conservative: we only normalize what is
+  # *known* to be equivalent for a given provider, so that we never merge two
+  # genuinely distinct addresses.
+
+  # Domains that are simple aliases of another (canonical) domain.
+  EMAIL_DOMAIN_ALIASES = {
+    "googlemail.com" => "gmail.com"
+  }.freeze
+
+  # Domains for which a "+suffix" in the local part is ignored (sub-addressing),
+  # i.e. "foo+anything@domain" delivers to the same mailbox as "foo@domain".
+  # This list can safely be extended with other providers sharing this behavior.
+  PLUS_ALIASING_EMAIL_DOMAINS = Set[
+    "gmail.com",
+    "outlook.com", "outlook.fr", "outlook.be",
+    "hotmail.com", "hotmail.fr", "hotmail.be",
+    "live.com",    "live.fr",    "live.be",
+    "msn.com"
+  ].freeze
+
+  # Domains for which dots in the local part are also ignored,
+  # i.e. "f.o.o@gmail.com" delivers to the same mailbox as "foo@gmail.com".
+  DOT_INSENSITIVE_EMAIL_DOMAINS = Set[
+    "gmail.com"
+  ].freeze
+
+  # Returns a canonical form of the given e-mail address (see explanations above).
+  # This is a pure function (no database access) so that it can be reused both in
+  # the validation below and in data migrations. Returns nil when blank.
+  def self.canonical_email(email)
+    return nil if email.nil?
+    email = email.strip.downcase
+    local, separator, domain = email.rpartition("@")
+    return email if separator.empty? # Not a "local@domain" address: leave as-is
+
+    domain = EMAIL_DOMAIN_ALIASES.fetch(domain, domain)
+
+    if PLUS_ALIASING_EMAIL_DOMAINS.include?(domain)
+      prefix = local.split("+", 2).first
+      local = prefix unless prefix.empty? # Keep local untouched for a leading "+"
+    end
+
+    if DOT_INSENSITIVE_EMAIL_DOMAINS.include?(domain)
+      local = local.delete(".")
+    end
+
+    "#{local}@#{domain}"
+  end
+
   # Tells if user is an administrator or a root
   def admin?
     return self.administrator? || self.root?
@@ -518,7 +579,29 @@ class User < ActiveRecord::Base
   end
   
   private
-  
+
+  # Keep the canonical_email column in sync with the email (see issue #108)
+  def set_canonical_email
+    self.canonical_email = User.canonical_email(self.email)
+  end
+
+  # Forbid a new account whose e-mail is an *alias* of an existing account's
+  # e-mail (same canonical form but a different spelling, e.g. "foo.bar@gmail.com"
+  # versus "foobar@gmail.com"). Exact duplicates (up to the case) are already
+  # reported by the standard uniqueness validation on :email, so we ignore them
+  # here to avoid showing two error messages for the same problem. See issue #108.
+  def email_is_not_an_alias_of_an_existing_one
+    return unless email_changed? # Only check when the address is set or modified
+    return if email.blank? || canonical_email.blank?
+    # Among the accounts sharing this canonical address, ignore the ones with the
+    # exact same e-mail (already handled by the standard uniqueness validation):
+    # if a genuine alias remains, the address is considered already used.
+    other_accounts = User.where.not(id: id).where(canonical_email: canonical_email)
+    if other_accounts.where.not("LOWER(email) = ?", email.strip.downcase).exists?
+      errors.add(:base, "Cette adresse e-mail est une variante d'une adresse déjà utilisée par un autre compte. Veuillez utiliser une autre adresse e-mail.")
+    end
+  end
+
   # Gives the corrector prefix (if any) for the name
   def corrector_prefix
     if (self.admin? || self.corrector?) && self.correction_level > 0

--- a/db/migrate/20260622090000_add_canonical_email_to_users.rb
+++ b/db/migrate/20260622090000_add_canonical_email_to_users.rb
@@ -1,0 +1,32 @@
+class AddCanonicalEmailToUsers < ActiveRecord::Migration[7.1]
+  # See issue #108: to make the creation of double accounts harder, we store a
+  # "canonical" version of each e-mail address (see User.canonical_email) and we
+  # forbid a new account whose canonical address is already used by another one.
+  #
+  # The index is voluntarily NOT unique: the current database may already contain
+  # such near-duplicates, and cleaning them up is out of the scope of this
+  # migration. The (non-unique) index still makes it cheap to:
+  #   * validate each new account, and
+  #   * list the already existing duplicates, for instance with:
+  #       SELECT canonical_email, COUNT(*) FROM users
+  #       GROUP BY canonical_email HAVING COUNT(*) > 1;
+  # Once those duplicates have been dealt with, the index could be made unique.
+  def up
+    add_column :users, :canonical_email, :string
+    add_index :users, :canonical_email
+
+    # Backfill existing users. We reuse User.canonical_email (a pure function that
+    # does not touch the database) so that the canonicalization logic stays
+    # defined in a single place. update_column skips validations and callbacks,
+    # which is exactly what we want here (and the users table has no updated_at).
+    User.reset_column_information
+    User.find_each do |user|
+      user.update_column(:canonical_email, User.canonical_email(user.email))
+    end
+  end
+
+  def down
+    remove_index :users, :canonical_email
+    remove_column :users, :canonical_email
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -35,6 +35,7 @@
 #  password_strength         :integer          default("unknown_password")
 #  accepted_code_of_conduct  :boolean          default(FALSE)
 #  whitelisted               :boolean          default(FALSE)
+#  canonical_email           :string
 #
 require "spec_helper"
 
@@ -142,7 +143,47 @@ describe User, user: true do
     end
     specify { expect(user.email).to eq(mixed_case_email.downcase) }
   end
-  
+
+  # Canonical email (to make double accounts harder, see issue #108)
+  describe "canonical email" do
+    specify "lowercases and trims any address" do
+      expect(User.canonical_email("  Foo.Bar@Example.COM ")).to eq("foo.bar@example.com")
+    end
+    specify "ignores dots and +suffix for Gmail addresses" do
+      expect(User.canonical_email("f.o.o@gmail.com")).to eq("foo@gmail.com")
+      expect(User.canonical_email("foo+anything@gmail.com")).to eq("foo@gmail.com")
+      expect(User.canonical_email("f.o.o+spam@gmail.com")).to eq("foo@gmail.com")
+    end
+    specify "treats googlemail.com as gmail.com" do
+      expect(User.canonical_email("f.o.o@googlemail.com")).to eq("foo@gmail.com")
+    end
+    specify "ignores +suffix but keeps dots for Outlook/Hotmail addresses" do
+      expect(User.canonical_email("john.doe+news@outlook.com")).to eq("john.doe@outlook.com")
+      expect(User.canonical_email("john+news@hotmail.be")).to eq("john@hotmail.be")
+    end
+    specify "leaves other providers untouched (apart from the case)" do
+      expect(User.canonical_email("f.o.o+bar@example.com")).to eq("f.o.o+bar@example.com")
+    end
+  end
+
+  describe "when email is an alias of an already used address" do
+    before do
+      FactoryBot.create(:user, email: "foo.bar@gmail.com", email_confirmation: "foo.bar@gmail.com")
+      user.email = "foobar+promo@gmail.com"
+      user.email_confirmation = "foobar+promo@gmail.com"
+    end
+    it { should_not be_valid }
+  end
+
+  describe "when email only shares its canonical form with itself" do
+    before do
+      FactoryBot.create(:user, email: "foo.bar@gmail.com", email_confirmation: "foo.bar@gmail.com")
+      user.email = "someone.else@gmail.com"
+      user.email_confirmation = "someone.else@gmail.com"
+    end
+    it { should be_valid }
+  end
+
   # Password
   describe "when password is not present" do
     before { user.password = user.password_confirmation = " " }


### PR DESCRIPTION
## Contexte (issue #108)

L'issue #108 signale que `foobar@gmail.com` et `foo.bar@gmail.com` sont aujourd'hui considérées comme deux adresses distinctes, alors qu'elles correspondent à la même boîte mail chez Gmail. Cela facilite la création de doubles-comptes. Le même problème existe avec le « +suffixe » (sous-adressage) chez Gmail, Outlook, Hotmail, etc.

## Approche

Plutôt que de normaliser l'adresse uniquement au moment de la comparaison, cette PR introduit une **forme canonique** persistée de chaque adresse :

- une nouvelle colonne `canonical_email` est calculée à partir de `email` via `User.canonical_email` (fonction pure, sans accès à la base) ;
- une nouvelle validation rejette tout compte dont la forme canonique est déjà utilisée par un **autre** compte.

L'adresse d'origine (`email`) est conservée telle quelle (affichage, envoi des e-mails) : `canonical_email` ne sert qu'aux comparaisons.

### Règles de canonicalisation (volontairement prudentes)

On ne normalise que ce qui est **connu** comme équivalent chez un fournisseur donné, afin de ne jamais fusionner deux adresses réellement différentes :

- mise en minuscules + suppression des espaces pour **toutes** les adresses ;
- suppression du « +suffixe » dans la partie locale pour Gmail, Outlook, Hotmail, Live et MSN (sous-adressage) ;
- suppression des points dans la partie locale **uniquement** pour Gmail (chez Outlook, les points sont significatifs et sont donc conservés) ;
- `googlemail.com` est traité comme un alias de `gmail.com`.

La liste des fournisseurs est facilement extensible (simples constantes).

## Choix de conception

- **Index non unique** sur `canonical_email` : la base actuelle peut déjà contenir de tels doublons (cf. commentaire de @Nicolas16 dans l'issue). Un index unique ferait échouer la migration. L'index permet malgré tout de lister facilement les doublons existants :

  ```sql
  SELECT canonical_email, COUNT(*) FROM users
  GROUP BY canonical_email HAVING COUNT(*) > 1;
  ```

  Une fois ces doublons traités, l'index pourra être rendu unique.

- **La validation ne se déclenche qu'au changement d'adresse** (`email_changed?`) : ainsi, un éventuel doublon déjà présent en base reste capable de modifier son profil sans être bloqué.

- **Les doublons exacts** (à la casse près) restent gérés par la validation d'unicité existante sur `:email` ; la nouvelle validation ne traite que les *variantes* (même forme canonique, orthographe différente), pour ne pas afficher deux messages d'erreur pour le même problème.

- **Connexion et mot de passe oublié inchangés** : la recherche continue de se faire sur l'adresse exacte (en minuscules), ce qui reste sans ambiguïté même si des doublons hérités existent. Une recherche basée sur la forme canonique pourrait faire l'objet d'une évolution ultérieure.

## Tests

- `User.canonical_email` est couvert pour chaque règle (Gmail points/+suffixe, googlemail, Outlook/Hotmail, autres fournisseurs) ;
- l'inscription est rejetée pour une adresse qui est une variante d'une adresse existante, et acceptée pour une adresse réellement différente.

Référence : #108
